### PR TITLE
In dev

### DIFF
--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -798,7 +798,7 @@ export class SMTXActor extends Actor {
 /**
  * Creates a floating text that rises and fades above a token.
  *
- * @param {Token} token      The token (PlaceableObject) above which the text appears
+ * @param {Token} token      The token (Document) above which the text appears
  * @param {string|number} textValue  The text to display (e.g. -10, +5)
  * @param {object} [options={}]      Optional styling/animation configs
  */
@@ -833,8 +833,6 @@ export function createFloatingNumber(token, textValue, options = {}) {
   floatingText.position.set(centerX, centerY);
 
   // Add to a container. 
-  // "canvas.tokens" works in many versions, but you could also use "canvas.foreground" or "canvas.interface"
-  // depending on your preference and Foundry version:
   canvas.tokens.addChild(floatingText);
 
   // Simple manual animation
@@ -856,7 +854,7 @@ export function createFloatingNumber(token, textValue, options = {}) {
     if (progress < 1) {
       requestAnimationFrame(animate);
     } else {
-      // Remove from the container and destroy to free resources
+      // Remove from the container and destroy it
       canvas.tokens.removeChild(floatingText);
       floatingText.destroy();
     }

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -423,7 +423,7 @@ export class SMTXActor extends Actor {
 
       ChatMessage.create({
         speaker: ChatMessage.getSpeaker({ actor: this }),
-        content: `<span style="font-size: var(--font-size-16);">${taruPowerContent} Powers Up.</span>`
+        content: `<span style="font-size: var(--font-size-16);">${taruPowerContent} Power Up.</span>`
       });
     }
     if (applyTo.rakukaja) {
@@ -431,7 +431,7 @@ export class SMTXActor extends Actor {
 
       ChatMessage.create({
         speaker: ChatMessage.getSpeaker({ actor: this }),
-        content: `<span style="font-size: var(--font-size-16);">Defenses Up.</span>`
+        content: `<span style="font-size: var(--font-size-16);">Defense Up.</span>`
       });
     }
     if (applyTo.makakaja) {
@@ -455,7 +455,7 @@ export class SMTXActor extends Actor {
 
       ChatMessage.create({
         speaker: ChatMessage.getSpeaker({ actor: this }),
-        content: `<span style="font-size: var(--font-size-16);">${taruPowerContent} Powers Down.</span>`
+        content: `<span style="font-size: var(--font-size-16);">${taruPowerContent} Power Down.</span>`
       });
     }
     if (applyTo.rakunda) {

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -807,7 +807,7 @@ export function createFloatingNumber(token, textValue, options = {}) {
   const style = new PIXI.TextStyle({
     fontFamily: "Arial",
     fontSize: options.crit ? 96 : 48,
-    fill: options.crit ? "FFFF00" : (options.fillColor || "#FF0000"), // Red for damage, green for healing, etc.
+    fill: options.crit ? "FFDD00" : (options.fillColor || "#FF0000"),
     stroke: "#000000",
     strokeThickness: 4,
     dropShadow: true,

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -806,10 +806,10 @@ export function createFloatingNumber(token, textValue, options = {}) {
   // Example style; tweak to fit your theme
   const style = new PIXI.TextStyle({
     fontFamily: "Arial",
-    fontSize: options.crit ? 96 : 48,
-    fill: options.crit ? "FFDD00" : (options.fillColor || "#FF0000"),
+    fontSize: 48,
+    fill: options.crit ? "FFCC00" : (options.fillColor || "#FF0000"),
     stroke: "#000000",
-    strokeThickness: 4,
+    strokeThickness: options.crit ? 6 : 4,
     dropShadow: true,
     dropShadowColor: "#000000",
     dropShadowBlur: 4,
@@ -838,6 +838,8 @@ export function createFloatingNumber(token, textValue, options = {}) {
   // Simple manual animation
   const animDistance = options.animDistance ?? 50;
   const animDuration = options.animDuration ?? 1250; // in ms
+  const initialScale = options.crit ? 1.5 : 1.0; // Start bigger if crit
+  floatingText.scale.set(initialScale);
   const startY = floatingText.y;
   const endY = floatingText.y - animDistance;
   const startTime = performance.now();
@@ -850,6 +852,11 @@ export function createFloatingNumber(token, textValue, options = {}) {
 
     floatingText.y = startY - animDistance * progress;
     floatingText.alpha = 1 - progress;
+
+    if (options.crit) {
+      const scaleProgress = 1 - progress;
+      floatingText.scale.set(1 + (initialScale - 1) * scaleProgress);
+    }
 
     if (progress < 1) {
       requestAnimationFrame(animate);

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -407,29 +407,72 @@ export class SMTXActor extends Actor {
       });
     };
 
+    let taruPowerContent = "Melee & Ranged";
+    if (game.settings.get("smt-200x", "taruOnly")) taruPowerContent = "All"
+
     if (applyTo.sukukaja) {
       updateBuffs("suku", "buff");
+
+      ChatMessage.create({
+        speaker: ChatMessage.getSpeaker({ actor: this }),
+        content: `<span style="font-size: var(--font-size-16);">All TN Accuracy Up.</span>`
+      });
     }
     if (applyTo.tarukaja) {
       updateBuffs("taru", "buff");
+
+      ChatMessage.create({
+        speaker: ChatMessage.getSpeaker({ actor: this }),
+        content: `<span style="font-size: var(--font-size-16);">${taruPowerContent} Powers Up.</span>`
+      });
     }
     if (applyTo.rakukaja) {
       updateBuffs("raku", "buff");
+
+      ChatMessage.create({
+        speaker: ChatMessage.getSpeaker({ actor: this }),
+        content: `<span style="font-size: var(--font-size-16);">Defenses Up.</span>`
+      });
     }
     if (applyTo.makakaja) {
       updateBuffs("maka", "buff");
+
+      ChatMessage.create({
+        speaker: ChatMessage.getSpeaker({ actor: this }),
+        content: `<span style="font-size: var(--font-size-16);">Spell Power Up.</span>`
+      });
     }
     if (applyTo.sukunda) {
       updateBuffs("suku", "debuff");
+
+      ChatMessage.create({
+        speaker: ChatMessage.getSpeaker({ actor: this }),
+        content: `<span style="font-size: var(--font-size-16);">All TN Accuracy Down.</span>`
+      });
     }
     if (applyTo.tarunda) {
       updateBuffs("taru", "debuff");
+
+      ChatMessage.create({
+        speaker: ChatMessage.getSpeaker({ actor: this }),
+        content: `<span style="font-size: var(--font-size-16);">${taruPowerContent} Powers Down.</span>`
+      });
     }
     if (applyTo.rakunda) {
       updateBuffs("raku", "debuff");
+
+      ChatMessage.create({
+        speaker: ChatMessage.getSpeaker({ actor: this }),
+        content: `<span style="font-size: var(--font-size-16);">Defense Down.</span>`
+      });
     }
     if (applyTo.makunda) {
       updateBuffs("maka", "debuff");
+
+      ChatMessage.create({
+        speaker: ChatMessage.getSpeaker({ actor: this }),
+        content: `<span style="font-size: var(--font-size-16);">Spell Power Down.</span>`
+      });
     }
   }
 

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -355,7 +355,7 @@ export class SMTXActor extends Actor {
 
     if (game.settings.get("smt-200x", "showFloatingDamage")) {
       for (let t of this.getActiveTokens()) {
-        createFloatingNumber(t.document, `-${finalAmount}`, { fillColor: "#FF0000", crit: crit });
+        createFloatingNumber(t.document, `-${finalAmount}`, { fillColor: "#FF0000", crit: crit, mult: mult });
       }
     }
   }
@@ -838,7 +838,7 @@ export function createFloatingNumber(token, textValue, options = {}) {
   // Simple manual animation
   const animDistance = options.animDistance ?? 50;
   const animDuration = options.animDuration ?? 1250; // in ms
-  const initialScale = options.crit ? 1.5 : 1.0; // Start bigger if crit
+  const initialScale = (options.crit ? 1.5 : 1.0) * ((options.mult == 0.5 ? 0.75 : options.mult == 2 ? 1.25 : 1) || 1); // Start bigger if crit
   floatingText.scale.set(initialScale);
   const startY = floatingText.y;
   const endY = floatingText.y - animDistance;

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -283,10 +283,11 @@ export class SMTXActor extends Actor {
 
 
 
-  async applyDamage(amount, mult, affinity = "almighty", ignoreDefense = false, affectsMP = false) {
+  async applyDamage(amount, mult, affinity = "almighty", ignoreDefense = false, halfDefense = false, crit = false, affectsMP = false) {
     let defense = this.system.magdef;
     if (affinity === "strike" || affinity === "gun") defense = this.system.phydef;
-    if (ignoreDefense) defense = 0;
+    if (ignoreDefense || crit) defense = 0;
+    if (halfDefense) defense = Math.floor(defense / 2);
 
     let damage = amount;
     let fateUsed = 0;

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -297,6 +297,7 @@ export class SMTXItem extends Item {
     let overrides = {
       affinity: systemData.affinity || "strike",
       ignoreDefense: systemData.ingoreDefense,
+      halfDefense: systemData.halfDefense,
       pierce: systemData.pierce,
       critMult: systemData.critMult || 2,
       extraModifier: "0",
@@ -345,6 +346,10 @@ export class SMTXItem extends Item {
                         <input type="checkbox" id="ignoreDefense" name="ignoreDefense" ${overrides.ignoreDefense ? "checked" : ""} />
                     </div>
                     <div class="form-group">
+                        <label for="halfDefense">Half Defense:</label>
+                        <input type="checkbox" id="halfDefense" name="halfDefense" ${overrides.halfDefense ? "checked" : ""} />
+                    </div>
+                    <div class="form-group">
                         <label for="pierce">Pierce (unusued):</label>
                         <input type="checkbox" id="pierce" name="pierce" ${overrides.pierce ? "checked" : ""} />
                     </div>
@@ -368,11 +373,12 @@ export class SMTXItem extends Item {
               callback: (html) => {
                 const affinity = html.find('select[name="affinity"]').val() || "strike";
                 const ignoreDefense = html.find('input[name="ignoreDefense"]').is(":checked");
+                const halfDefense = html.find('input[name="halfDefense"]').is(":checked");
                 const pierce = html.find('input[name="pierce"]').is(":checked");
                 const critMult = parseFloat(html.find('input[name="critMult"]').val()) || 2;
                 const extraModifier = html.find('input[name="extraModifier"]').val() || "0";
                 const baseMult = html.find('input[name="baseMult"]').val() || "1";
-                resolve({ affinity, ignoreDefense, pierce, critMult, extraModifier, baseMult });
+                resolve({ affinity, ignoreDefense, halfDefense, pierce, critMult, extraModifier, baseMult });
               },
             },
             cancel: {
@@ -460,6 +466,7 @@ export class SMTXItem extends Item {
     <div class="power-roll-card"
          data-affinity="${overrides.affinity}" 
          data-ignore-defense="${overrides.ignoreDefense}" 
+         data-half-defense="${overrides.halfDefense}" 
          data-pierce="${overrides.pierce}" 
          data-affects-mp='${systemData.affectsMP}' 
          data-regular-damage="${finalBaseDmg}" 
@@ -519,6 +526,7 @@ Hooks.on('renderChatMessage', (message, html, data) => {
   const criticalDamage = parseFloat(powerRollCard.data('critical-damage'));
   const affinity = powerRollCard.data('affinity');
   const ignoreDefense = powerRollCard.data('ignore-defense');
+  const halfDefense = powerRollCard.data('half-defense');
   const pierce = powerRollCard.data('pierce');
   const affectsMP = powerRollCard.data('affects-mp');
   const buffsArray = powerRollCard.data('buffs');
@@ -538,7 +546,7 @@ Hooks.on('renderChatMessage', (message, html, data) => {
       if (heals)
         actor.applyHeal(amount, affectsMP);
       else
-        actor.applyDamage(amount, mult, affinity, (crit || ignoreDefense), pierce, affectsMP);
+        actor.applyDamage(amount, mult, affinity, ignoreDefense, halfDefense, crit, pierce, affectsMP);
     });
   };
 

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -296,8 +296,8 @@ export class SMTXItem extends Item {
 
     let overrides = {
       affinity: systemData.affinity || "strike",
-      ignoreDefense: systemData.ignoreDefense || false,
-      pierce: systemData.pierce || false,
+      ignoreDefense: systemData.ingoreDefense,
+      pierce: systemData.pierce,
       critMult: systemData.critMult || 2,
       extraModifier: "0",
       baseMult: 1

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -495,7 +495,7 @@ export class SMTXActorSheet extends ActorSheet {
 
     html.on('click', '.spell-power-roll', async (event) => {
       event.preventDefault();
-      this.actor.rollPower("(@powerDice.spell)d10x + @spellPower", true)
+      this.actor.rollPower("(@powerDice.spell)d10x + @spellPower", "almighty", true)
     });
 
     html.on('contextmenu', '.spell-power-roll', async (event) => {

--- a/module/smt-200x.mjs
+++ b/module/smt-200x.mjs
@@ -94,6 +94,15 @@ Hooks.once('init', function () {
     default: false
   });
 
+  game.settings.register("smt-200x", "showFloatingDamage", {
+    name: "Show Floating Damage Text",
+    hint: "Shows floating text for the damage or healing applied to a token.",
+    scope: "world", // World-level setting (shared by all players)
+    config: true,
+    type: Boolean,
+    default: false
+  });
+
   /*// Register a number setting
   game.settings.register("my-system", "maxItems", {
     name: "Maximum Items",

--- a/system.json
+++ b/system.json
@@ -20,7 +20,7 @@
       "thumbnail": "systems/smt-200x/assets/anvil-impact.png"
     }
   ],
-  "version": "0.852",
+  "version": "0.853",
   "compatibility": {
     "minimum": 12,
     "verified": "12.331"
@@ -50,7 +50,7 @@
   "packFolders": [],
   "socket": false,
   "manifest": "https://github.com/Alondaar/smt-200x/raw/main/system.json",
-  "download": "https://github.com/Alondaar/smt-200x/archive/refs/tags/release-020.zip",
+  "download": "https://github.com/Alondaar/smt-200x/archive/refs/tags/release-021.zip",
   "background": "systems/smt-200x/assets/anvil-impact.png",
   "gridDistance": 2,
   "gridUnits": "m",

--- a/templates/item/item-feature-sheet.hbs
+++ b/templates/item/item-feature-sheet.hbs
@@ -163,6 +163,11 @@
         </div>
 
         <div class="flexcol">
+          <label for="system.halfDefense" class="resource-label">Ignores 1/2 Defense</label>
+          <input type="checkbox" name="system.halfDefense" {{#if system.halfDefense}}checked{{/if}} />
+        </div>
+
+        <div class="flexcol">
           <label for="system.pierce" class="resource-label">Pierce (unused)</label>
           <input type="checkbox" name="system.pierce" {{#if system.pierce}}checked{{/if}} />
         </div>


### PR DESCRIPTION
New update v0.853:
This is a non-breaking update, so there should be nothing to worry about if it asks for world-migration.
- FIX: Ignore Defense option in feature-items now functions properly.
- FIX: Left clicking Spell Power now performs a quick roll like the ther Powers
- ADD: Chat message when applying buff effects (tarukaja etc)
- ADD: An Ignore Half Defense option for that one gun skill in Tokyo Conception
- ADD: Floating combat text for applied damage/healing. See the system options to enable it.