### PR TITLE
In dev

### DIFF
--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -109,6 +109,8 @@ export class SMTXActor extends Actor {
       let physicalDefense = 0;
       let magicalDefense = 0;
       let meleePower = 0;
+      let rangedPower = 0;
+      let spellPower = 0;
       let initiative = 0;
 
       // Add defense bonuses from equipped armor
@@ -118,6 +120,8 @@ export class SMTXActor extends Actor {
           physicalDefense += item.system.phydef ?? 0;
           magicalDefense += item.system.magdef ?? 0;
           meleePower += item.system.meleePower ?? 0;
+          rangedPower += item.system.rangedPower ?? 0;
+          spellPower += item.system.spellPower ?? 0;
           initiative += item.system.init ?? 0;
         }
       });
@@ -126,6 +130,8 @@ export class SMTXActor extends Actor {
       systemData.phydef += physicalDefense;
       systemData.magdef += magicalDefense;
       systemData.meleePower += meleePower;
+      systemData.rangedPower += rangedPower;
+      systemData.spellPower += spellPower;
       systemData.init += initiative;
     }
 

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -96,6 +96,14 @@ export class SMTXActor extends Actor {
     systemData.phydef = this.parseFormula(systemData.phydefFormula) + systemData.sumRaku;
     systemData.magdef = this.parseFormula(systemData.magdefFormula) + systemData.sumRaku;
 
+    // INITIATIVE
+    systemData.init = this.parseFormula(systemData.initFormula);
+
+    // POWERS
+    systemData.meleePower = systemData.stats.st.value + systemData.attributes.level + systemData.sumTaru;
+    systemData.spellPower = systemData.stats.mg.value + systemData.attributes.level + (game.settings.get("smt-200x", "taruOnly") ? systemData.sumTaru : systemData.sumMaka);
+    systemData.rangedPower = systemData.stats.ag.value + (game.settings.get("smt-200x", "addLevelToRangedPower") ? systemData.attributes.level : 0) + systemData.sumTaru;
+
     if (actorData.type === 'character') {
       // Start with base values
       let physicalDefense = 0;
@@ -106,10 +114,11 @@ export class SMTXActor extends Actor {
       // Add defense bonuses from equipped armor
       this.items.forEach((item) => {
         if (item.type === "armor" && item.system.equipped) {
-          physicalDefense += item.system.phydef || 0;
-          magicalDefense += item.system.magdef || 0;
-          meleePower += item.system.meleePower || 0;
-          initiative += item.system.init || 0;
+          console.log(item.system);
+          physicalDefense += item.system.phydef ?? 0;
+          magicalDefense += item.system.magdef ?? 0;
+          meleePower += item.system.meleePower ?? 0;
+          initiative += item.system.init ?? 0;
         }
       });
 
@@ -119,14 +128,6 @@ export class SMTXActor extends Actor {
       systemData.meleePower += meleePower;
       systemData.init += initiative;
     }
-
-    // INITIATIVE
-    systemData.init = this.parseFormula(systemData.initFormula);
-
-    // POWERS
-    systemData.meleePower = systemData.stats.st.value + systemData.attributes.level + systemData.sumTaru;
-    systemData.spellPower = systemData.stats.mg.value + systemData.attributes.level + (game.settings.get("smt-200x", "taruOnly") ? systemData.sumTaru : systemData.sumMaka);
-    systemData.rangedPower = systemData.stats.ag.value + (game.settings.get("smt-200x", "addLevelToRangedPower") ? systemData.attributes.level : 0) + systemData.sumTaru;
 
     // Set Max HP / MP / Fate
     systemData.hp.max = (systemData.stats.vt.value + systemData.attributes.level) * systemData.hp.mult;

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -156,14 +156,27 @@ export class SMTXItem extends Item {
     // Initialize chat data.
     const speaker = ChatMessage.getSpeaker({ actor: this.actor });
     const rollMode = game.settings.get('core', 'rollMode');
-    const label = `<h2>${item.name}</h2>`; //[${item.type}]
+    const itemImg = item.img ? `<img src="${item.img}" style="width:32px; height:32px; vertical-align:middle; margin-right:5px;">` : '';
+    const label = `<h2 style="display: flex; align-items: center;">${itemImg} ${item.name}</h2>`;
 
-    ChatMessage.create({
-      speaker: speaker,
-      rollMode: rollMode,
-      flavor: label,
-      content: (item.system.shortEffect + `<hr>` + item.system.description) ?? '',
-    });
+    switch (item.type) {
+      case 'feature':
+        ChatMessage.create({
+          speaker: speaker,
+          rollMode: rollMode,
+          flavor: label,
+          content: (item.system.shortEffect + `<hr>` + item.system.description) ?? '',
+        });
+        break;
+
+      default:
+        ChatMessage.create({
+          speaker: speaker,
+          rollMode: rollMode,
+          flavor: label,
+          content: (item.system.shortEffect + `<hr>` + item.system.description) ?? '',
+        });
+    }
   }
 
 

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -522,7 +522,7 @@ export class SMTXItem extends Item {
     if (game.dice3d)
       await game.dice3d.showForRoll(regularRoll, game.user, true)
 
-    const finalBaseDmg = (regularRoll.total) * overrides.baseMult
+    const finalBaseDmg = Math.floor((regularRoll.total) * overrides.baseMult)
 
     // Roll for sub-formula
     const hasBuffSubRoll = systemData.subBuffRoll != "" ? true : false;
@@ -564,7 +564,7 @@ export class SMTXItem extends Item {
       .join(", "); // Join the values into a string
 
     // Calculate critical damage
-    const critDamage = (finalBaseDmg * overrides.critMult) + systemData.flatCritDamage;
+    const critDamage = Math.floor((finalBaseDmg) * overrides.critMult) + systemData.flatCritDamage;
 
     // Determine button visibility based on affinity
     const hideDamage = (hasBuffs && !hasBuffSubRoll);

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -158,25 +158,45 @@ export class SMTXItem extends Item {
     const rollMode = game.settings.get('core', 'rollMode');
     const itemImg = item.img ? `<img src="${item.img}" style="width:32px; height:32px; vertical-align:middle; margin-right:5px;">` : '';
     const label = `<h2 style="display: flex; align-items: center;">${itemImg} ${item.name}</h2>`;
+    let content = (item.system.shortEffect + `<hr>` + item.system.description) ?? ''
 
     switch (item.type) {
       case 'feature':
-        ChatMessage.create({
-          speaker: speaker,
-          rollMode: rollMode,
-          flavor: label,
-          content: (item.system.shortEffect + `<hr>` + item.system.description) ?? '',
-        });
+        const cost = item.system.cost ?? 'N/A';
+        const target = item.system.target ?? 'N/A';
+        const tn = item.system.calcTN ?? 'N/A';
+        const power = item.system.calcPower ?? 'N/A';
+        const affinity = item.system.affinity ?? 'N/A';
+
+        const featureInfo = `
+          <div class="flexrow flex-center flex-between" style="display: flex; align-items: center;">
+            <span><strong>Cost</strong></span>
+            <span><strong>Target</strong></span>
+            <span><strong>Affinity</strong></span>
+          </div>
+          <div class="flexrow flex-center flex-between" style="display: flex; align-items: center;">
+            <span>${cost}</span>
+            <span>${target}</span>
+            <span>${game.i18n.localize("SMT_X.Affinity." + affinity)}</span>
+          </div>
+          <hr>
+        `;
+
+        // <div class="flexrow flex-center flex-between" style="display: flex; align-items: center;"><span><strong>TN:</strong> ${tn}</span><span><strong>Power:</strong> ${power}</span></div>
+
+        content = featureInfo + content;
         break;
 
       default:
-        ChatMessage.create({
-          speaker: speaker,
-          rollMode: rollMode,
-          flavor: label,
-          content: (item.system.shortEffect + `<hr>` + item.system.description) ?? '',
-        });
+        break;
     }
+
+    ChatMessage.create({
+      speaker: speaker,
+      rollMode: rollMode,
+      flavor: label,
+      content: content,
+    });
   }
 
 

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -315,7 +315,7 @@ export class SMTXItem extends Item {
           result = "Critical"; // Natural 1 is always a critical
         } else if (roll.total === 100) {
           result = "Fumble"; // Natural 100 is always a fumble
-        } else if (roll.total >= (this.actor.isCursed ? 86 : 96) && roll.total <= 99) {
+        } else if (roll.total >= (this.actor.system.isCursed ? 86 : 96) && roll.total <= 99) {
           result = "Automatic Failure"; // Rolls 96+ (Cursed 86+) are automatic failures
         } else if (roll.total <= (tn * critRate) + systemData.flatCritChance) {
           result = "Critical"; // Within the crit rate range

--- a/system.json
+++ b/system.json
@@ -20,7 +20,7 @@
       "thumbnail": "systems/smt-200x/assets/anvil-impact.png"
     }
   ],
-  "version": "0.854",
+  "version": "0.855",
   "compatibility": {
     "minimum": 12,
     "verified": "12.331"
@@ -50,7 +50,7 @@
   "packFolders": [],
   "socket": false,
   "manifest": "https://github.com/Alondaar/smt-200x/raw/main/system.json",
-  "download": "https://github.com/Alondaar/smt-200x/archive/refs/tags/release-022.zip",
+  "download": "https://github.com/Alondaar/smt-200x/archive/refs/tags/release-023.zip",
   "background": "systems/smt-200x/assets/anvil-impact.png",
   "gridDistance": 2,
   "gridUnits": "m",

--- a/template.json
+++ b/template.json
@@ -278,6 +278,8 @@
       "magdef": 0,
       "equipped": false,
       "meleePower": 0,
+      "rangedPower": 0,
+      "spellPower": 0,
       "init": 0,
       "st": 0,
       "mg": 0,

--- a/templates/item/item-armor-sheet.hbs
+++ b/templates/item/item-armor-sheet.hbs
@@ -47,6 +47,16 @@
         </div>
 
         <div class="flexcol">
+          <label for="system.rangedPower" class="resource-label">Ranged Power Bonus</label>
+          <input type="text" name="system.rangedPower" value="{{system.rangedPower}}" data-dtype="Number" />
+        </div>
+
+        <div class="flexcol">
+          <label for="system.spellPower" class="resource-label">Spell Power Bonus</label>
+          <input type="text" name="system.spellPower" value="{{system.spellPower}}" data-dtype="Number" />
+        </div>
+
+        <div class="flexcol">
           <label for="system.init" class="resource-label">Initiative Bonus</label>
           <input type="text" name="system.init" value="{{system.init}}" data-dtype="Number" />
         </div>


### PR DESCRIPTION
New update v0.855:
This is a non-breaking update, so there should be nothing to worry about if it asks for world-migration.
- FIX: Order of operations preventing Melee Power and Init bonuses on equippable armor items from applying.
- ADD: Armor items now have fields for Ranged Power and Spell Power too.
- ADD: When clicking an item's icon (referred to as "Showing the item") the item's icon now appears in the chat.
- ADD: Extra information and formatting is displayed when showing Feature items. (cost, target, affinity)
- CHANGE: d100 checks & power rolls now have improved formatting and readability.
- FIX: Power roll damage/heal buttons escaping the bounds of the chat message
- FIX: An actor's "isCursed" checkbox is now read correctly for the purposes of automatic failures