### PR TITLE
v0.878

### DIFF
--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -238,6 +238,8 @@ export class SMTXActor extends Actor {
 
 
   _setDerivedBSAffinities(systemData) {
+    // TODO: Clamp these to just Normal, Weak, Resist, Null
+    // Factor in "Null BS" and similar
     // Define the mapping: each BS type is associated with a primary affinity type.
     const bsMapping = {
       "STONE": "death",

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -683,7 +683,7 @@ export class SMTXActor extends Actor {
       finalAmount = Math.max(Math.floor((damage - defense) * affinityMod), 0);
     }
 
-    if (affinityMod < 0) {
+    if (affinityMod < 0 || mult < 0) {
       // For drain, call applyHeal instead and exit.
       this.applyHeal(amount, affectsMP);
       return;

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -634,7 +634,8 @@ export class SMTXActor extends Actor {
         ${fateUsed > 0 ? `<br><em>(Spent ${fateUsed} Fate Point${fateUsed > 1 ? 's' : ''}.)</em>` : ''}
         ${defenseBonus !== 0 ? `<br><em>Defense Bonus: ${defenseBonus}</em>` : ''}
       </span>
-      <button class="flex0 undo-damage height: 32px; width: 32px;" 
+      ${game.user.isGM ?
+        `<button class="flex0 undo-damage height: 32px; width: 32px;" 
               data-actor-id="${this.id}" 
               data-token-id="${this.token ? this.token.id : ''}" 
               data-damage="${damageApplied}" 
@@ -642,7 +643,7 @@ export class SMTXActor extends Actor {
               style="margin-left: auto;">
         <i class="fas fa-undo"></i>
       </button>
-    </div>
+    </div>` : ``}
     `;
 
     ChatMessage.create({

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1079,7 +1079,10 @@ export class SMTXItem extends Item {
           <strong>${result.tokenName}:</strong>
           <span>(${game.i18n.localize((game.settings.get("smt-200x", "showTCheaders")
         ? "SMT_X.CharAffinity_TC."
-        : "SMT_X.CharAffinity.") + result.affinityStrength)})</span>
+        : "SMT_X.CharAffinity.") + result.affinityStrength)} 
+           ${game.i18n.localize((game.settings.get("smt-200x", "showTCheaders")
+          ? "SMT_X.Affinity_TC."
+          : "SMT_X.Affinity.") + systemData.affinity)})</span>
           <span>${result.badStatus != "NONE"
           ? game.i18n.localize((game.settings.get("smt-200x", "showTCheaders")
             ? "SMT_X.AffinityBS_TC."

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1083,7 +1083,18 @@ export class SMTXItem extends Item {
               data-ignore-defense="true"
             >CUT</button>
           </div>`
-          : ""}  
+          : ""}
+    ${(systemData.hpSet)
+          ? `<div class="flexrow"><span class="flex3">HP set to ${systemData.hpSet == -1 ? `Full` : systemData.hpSet} !!</span>
+            <button class="apply-damage-btn smtx-roll-button" title="Apply Damage" 
+              data-token-id="${result.tokenId}"
+              data-mult="${systemData.hpSet == -1 ? -1 : 1}"
+              data-effective-damage="${systemData.hpSet == -1 ? currentToken.actor.system.hp.max : currentToken.actor.system.hp.value - systemData.hpSet}"
+              data-affinity="almighty"
+              data-ignore-defense="true"
+            >SET</button>
+          </div>`
+          : ""}
 </div><hr>`;
     });
 
@@ -1454,6 +1465,7 @@ Hooks.on('renderChatMessage', (message, html, data) => {
     const tokenId = button.data("token-id");
     const effectiveDamage = Number(button.data("effective-damage"));
     const affinity = button.data("affinity");
+    const mult = button.data("mult") ?? 1;
     const ignoreDefense = button.data("ignore-defense");
     const halfDefense = button.data("half-defense");
     const critical = button.data("critical") === "true" || button.data("critical") === true;
@@ -1465,7 +1477,7 @@ Hooks.on('renderChatMessage', (message, html, data) => {
     if (!token || !token.actor) return;
     await token.actor.applyDamage(
       effectiveDamage,
-      1,
+      mult,
       affinity,
       ignoreDefense,
       halfDefense,

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -826,10 +826,11 @@ export class SMTXItem extends Item {
     const messageContainer = $(event.currentTarget).closest(".message-content");
 
     // --- 1. Determine Outcome for This Split ---
-    const rollDescElem = document.querySelector(`.roll-results-container .roll-result-desc[data-split-index="${splitIndex}"]`);
+    const rollDescElem = messageContainer.find(`.roll-result-desc[data-split-index="${splitIndex}"]`);
     let outcome = "Success";
     if (rollDescElem) {
-      const text = rollDescElem.textContent.toLowerCase();
+      console.log(rollDescElem[0].innerText)
+      const text = rollDescElem[0].innerText.toLowerCase();
       if (text.includes("critical")) outcome = "Critical";
     }
     const baseEffect = (outcome === "Critical") ? 2 : 1;

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -84,11 +84,19 @@ export class SMTXItem extends Item {
 
     // Condense Power modifier, set up template for X Booster effect
     const modPowerRoll = new Roll(`(${systemData.modPower}) + ${weaponPower}`, rollData).evaluateSync({ minimize: true });
-    const modPower = Math.floor((modPowerRoll.total - (modPowerRoll.dice.reduce((sum, die) => sum + die.number, 0))) /** (rollData.booster[systemData.affinity] ?? 1)*/);
+    let booster = 1; // Flat multiplier (x2 per rules) to the Skill's Power Mod
+    if (rollData.booster)
+      if (rollData.booster[systemData.affinity])
+        booster = rollData.booster[systemData.affinity];
+    const modPower = Math.floor((modPowerRoll.total - (modPowerRoll.dice.reduce((sum, die) => sum + die.number, 0))) * booster);
 
     // Condense Power base, set up template for X Boost effect TODO
     const basePowerRoll = new Roll(`(${basePower}) + ${modPower}`, rollData).evaluateSync({ minimize: true });
-    const staticPower = Math.floor((basePowerRoll.total - basePowerRoll.dice.reduce((sum, die) => sum + die.number, 0)) * systemData.powerBoost);
+    let boost = systemData.powerBoost; // Flat multiplier (x1.5 per rules) to the Skill's Final Power
+    if (rollData.boost)
+      if (rollData.boost[systemData.affinity])
+        boost = rollData.boost[systemData.affinity];
+    const staticPower = Math.floor((basePowerRoll.total - basePowerRoll.dice.reduce((sum, die) => sum + die.number, 0)) * boost);
 
     systemData.calcPower = displayDice + (displayDice && staticPower ? "+" : "") + (staticPower ? Math.floor(staticPower * (isPoisoned && systemData.attackType != "none" ? 0.5 : 1)) : "");
     systemData.calcPower = systemData.calcPower == "0" || systemData.calcPower == 0 ? "-" : systemData.calcPower;

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1063,7 +1063,7 @@ export class SMTXItem extends Item {
       }))).filter(result => result.badStatus.toUpperCase() !== "DEAD");
 
     // --- 6. Log the Damage Roll Results ---
-    let logMessage = `${diceHtml} ${buffContent}`;
+    let logMessage = `${baseDamage > 0 ? diceHtml : ``} ${buffContent}`;
     damageResults.forEach(result => {
       let currentToken = canvas.tokens.get(result.tokenId);
       logMessage += `<div class="flexcol target-row" data-token-id="${result.tokenId}" style="margin: 10px 0px">
@@ -1078,6 +1078,7 @@ export class SMTXItem extends Item {
             : "SMT_X.AffinityBS.") + result.badStatus)
           : ""}</span>
          </div>
+         ${baseDamage > 0 ? `
   <div class="flexrow"><span class="flex3"><strong>Inc. Dmg:</strong> ${result.finalDamage}</span>
     <button class="apply-damage-btn smtx-roll-button" title="Apply Damage" 
       data-token-id="${result.tokenId}"
@@ -1090,12 +1091,19 @@ export class SMTXItem extends Item {
       data-lifedrain="${systemData.lifeDrain}"
       data-manadrain="${systemData.manaDrain}"
     >DMG</button>
-    </div>
+    </div>` : ``}
     ${(systemData.appliesBadStatus != "NONE" && result.rawBSchance > 0)
-          ? `<div>${result.ailmentChance}% ${systemData.appliesBadStatus} (${result.bsAffinity})</div>`
+          ? `<div>${result.ailmentChance}% ${systemData.appliesBadStatus} (Roll: ${result.ailmentRoll})</div>`
           : ""}  
     ${(systemData.hpCut > 0)
-          ? `<div>Current HP cut by ${Math.floor(systemData.hpCut * 100)}% ! (${currentToken.actor.system.hp.value} -> ${Math.floor(currentToken.actor.system.hp.value * systemData.hpCut)})</div>`
+          ? `<div class="flexrow"><span class="flex3">HP cut to ${Math.floor(systemData.hpCut * 100)}% ! (${currentToken.actor.system.hp.value} -> ${Math.floor(currentToken.actor.system.hp.value * systemData.hpCut)})</span>
+            <button class="apply-damage-btn smtx-roll-button" title="Apply Damage" 
+              data-token-id="${result.tokenId}"
+              data-effective-damage="${currentToken.actor.system.hp.value - Math.floor(currentToken.actor.system.hp.value * systemData.hpCut)}"
+              data-affinity="almighty"
+              data-ignore-defense="true"
+            >CUT</button>
+          </div>`
           : ""}  
 </div><hr>`;
     });
@@ -1107,9 +1115,6 @@ export class SMTXItem extends Item {
       flavor: `${item.name} Effect (${splitIndex + 1})`,
       content: logMessage
     });
-
-    // --- 7. Remove automatic damage application ---
-    // Damage will now be applied when the user clicks the "Apply Damage" button.
   }
 }
 

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -837,7 +837,6 @@ export class SMTXItem extends Item {
     const rollDescElem = messageContainer.find(`.roll-result-desc[data-split-index="${splitIndex}"]`);
     let outcome = "Success";
     if (rollDescElem) {
-      console.log(rollDescElem[0].innerText)
       const text = rollDescElem[0].innerText.toLowerCase();
       if (text.includes("critical")) outcome = "Critical";
     }

--- a/system.json
+++ b/system.json
@@ -20,7 +20,7 @@
       "thumbnail": "systems/smt-200x/assets/anvil-impact.png"
     }
   ],
-  "version": "0.876",
+  "version": "0.878",
   "compatibility": {
     "minimum": 12,
     "verified": "12.331"
@@ -50,7 +50,7 @@
   "packFolders": [],
   "socket": true,
   "manifest": "https://github.com/Alondaar/smt-200x/raw/main/system.json",
-  "download": "https://github.com/Alondaar/smt-200x/archive/refs/tags/release-027.zip",
+  "download": "https://github.com/Alondaar/smt-200x/archive/refs/tags/release-028.zip",
   "background": "systems/smt-200x/assets/anvil-impact.png",
   "gridDistance": 2,
   "gridUnits": "m",

--- a/template.json
+++ b/template.json
@@ -432,6 +432,7 @@
       "fateCost": "0",
       "ammoCost": "0",
       "hideCritDamage": false,
+      "affectsHP": true,
       "affectsMP": false,
       "actionPattern": "-",
       "appliesBadStatus": "NONE",

--- a/template.json
+++ b/template.json
@@ -369,6 +369,7 @@
       "mpCost": "0",
       "fateCost": "0",
       "hideCritDamage": true,
+      "affectsHP": true,
       "affectsMP": false,
       "actionPattern": "-",
       "reloads": false,
@@ -379,6 +380,7 @@
       "lifeDrain": 0,
       "manaDrain": 0,
       "hpCut": 0,
+      "hpSet": "",
       "buffs": {
         "sukukaja": false,
         "sukunda": false,

--- a/templates/item/item-feature-sheet.hbs
+++ b/templates/item/item-feature-sheet.hbs
@@ -186,6 +186,11 @@
         </div>
 
         <div class="flexcol">
+          <label for="system.affectsHP" class="resource-label">Affects HP</label>
+          <input type="checkbox" name="system.affectsHP" {{#if system.affectsHP}}checked{{/if}} />
+        </div>
+
+        <div class="flexcol">
           <label for="system.affectsMP" class="resource-label">Affects MP</label>
           <input type="checkbox" name="system.affectsMP" {{#if system.affectsMP}}checked{{/if}} />
         </div>
@@ -219,6 +224,13 @@
           <label for="system.hpCut" class="resource-label" title="Reduce a target's current HP by this percentage">HP
             Cut</label>
           <input type="text" name="system.hpCut" value="{{system.hpCut}}" data-dtype="Number" />
+        </div>
+
+        <div class="flexcol">
+          <label for="system.hpSet" class="resource-label"
+            title="Set a target's HP to this value. Blank for no effect; Use -1 to set to Full HP">HP
+            Set</label>
+          <input type="text" name="system.hpSet" value="{{system.hpSet}}" data-dtype="Number" />
         </div>
       </div>
 


### PR DESCRIPTION
## New Version 0.878
- Fixed a bug that prevented Critical hits from calculating properly in the Effect/Damage output
- Added a button to apply HP cutting
- Hide the damage/power info if its not greater than 0
- Added an affectsHP checkbox (currently non functional, but will be in the future)
- Added an hpSet field, with an associated button to apply it to a target.
  - Setting this field to -1 will give you a Full Heal effect...
- Integrated Booster and Boost datapaths (Create an Active Effect passive for this)
  - The path you should use is `system.boost.?` or `system.booster.?` where "?" is the affinity (elec, fire, ice, etc.)
  - boost is an overall power multiplier
  - booster is a multiplier on JUST the skill's power modifier (Zio has +10 for example)
- The undo-damage button is now only visible to GM users
- The Effect/Damage report now shows the type of damage (prev would say "Weak" now says "Weak XX")
- Cosmetic Refactoring to the sheet Affinity display. Basically, if a wide category is set (Resist Magic) it will only show higher priority Affinities (such as Null Fire)
- Related to the cosmetic Affinity refactor, Magic and Ailment categorical Affinities are now factored in what I believe to be the Most Correct way
  - That is, they do not stack with similar Affinities (disregarding the Ailment Chance example in the books)
  - So, Weak Ice & Weak Magic does not result in x4 damage or ailment chance
  - Weak FREEZE & Weak Ailment does not result in x4 ailment chance
  - The "Element" and "Status" categories do still overlap though