### PR TITLE
v0.881

### DIFF
--- a/css/smt-200x.css
+++ b/css/smt-200x.css
@@ -337,8 +337,8 @@
 }
 
 .smt-200x .items-list .item-controls {
-  /*display: flex;
-  flex: 0 0 80px;*/
+  display: flex;
+  flex: 0 0 40px;
   justify-content: flex-end;
 }
 
@@ -431,6 +431,8 @@
   display: flex;
   gap: 4px;
   min-height: 20px;
+  margin-top: auto;
+  margin-bottom: auto;
   margin-right: 6px;
 }
 

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -278,6 +278,43 @@ export class SMTXActorSheet extends ActorSheet {
     });
 
 
+
+    // Ensure the expanded state container exists on the sheet instance
+    if (!this.expandedFeatures) {
+      this.expandedFeatures = {};
+    }
+
+    // Your other listeners...
+    // Example listener for the toggle event:
+    html.on('click', '.toggle-details', (ev) => {
+      // Find the closest main feature row
+      const $mainItem = $(ev.currentTarget).closest('li.item');
+      // The details row is assumed to be immediately after the main row.
+      const $details = $mainItem.next('li.item-details');
+      // Get the item ID for later state management.
+      const itemId = $mainItem.data('itemId');
+
+      // Toggle the details with slide animation, and update state after animation completes.
+      $details.slideToggle(200, () => {
+        // Now update the expanded state based on the actual visibility
+        this.expandedFeatures[itemId] = $details.is(':visible');
+      });
+    });
+
+    // After all listeners are attached, restore any already expanded detail rows.
+    html.find('li.item').each((i, li) => {
+      const $li = $(li);
+      const itemId = $li.data('itemId');
+      // Check if this feature was previously expanded
+      if (this.expandedFeatures[itemId]) {
+        // Find the corresponding details row and show it
+        const $details = $li.next('li.item-details');
+        $details.show();
+      }
+    });
+
+
+
     // Handle pip clicks
     html.on('click', '.pip', (ev) => {
       const li = $(ev.currentTarget).parents('.item');

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -704,9 +704,6 @@ export class SMTXActorSheet extends ActorSheet {
         return
       }
 
-
-      console.log(data);
-
       if (data.type && data.type == "Item") {
         return //ui.notifications.warn("This is an item dragged from a compendium, not an effect dragged from a used skill")
       }

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -705,6 +705,11 @@ export class SMTXActorSheet extends ActorSheet {
       }
 
 
+      console.log(data);
+
+      if (data.type && data.type == "Item") {
+        return //ui.notifications.warn("This is an item dragged from a compendium, not an effect dragged from a used skill")
+      }
 
       const uuid = (typeof data === "object" && data.uuid) ? data.uuid : data;
       if (!uuid || !uuid.includes("Compendium") || uuid.split(".").length < 4) {

--- a/module/smt-200x.mjs
+++ b/module/smt-200x.mjs
@@ -692,7 +692,12 @@ Handlebars.registerHelper("showTC", function () {
 
 Hooks.once('ready', function () {
   // Wait to register hotbar drop hook on ready so that modules could register earlier if they want to
-  Hooks.on('hotbarDrop', (bar, data, slot) => createItemMacro(data, slot));
+  //Hooks.on('hotbarDrop', (bar, data, slot) => createItemMacro(data, slot));
+
+  Hooks.on("hotbarDrop", (bar, data, slot) => {
+    createItemMacro(data, slot);
+    return false;
+  });
 
   // FRIENDLY
   if (!game.friendlyEffectsWidget) {
@@ -733,17 +738,23 @@ Hooks.on("updateToken", (tokenDocument, changeData, options, userId) => {
  * @returns {Promise}
  */
 async function createItemMacro(data, slot) {
-  // First, determine if this is a valid owned item.
+  // First, determine if this is a valid owned Item.
   if (data.type !== 'Item') return;
   if (!data.uuid.includes('Actor.') && !data.uuid.includes('Token.')) {
     return ui.notifications.warn(
       'You can only create macro buttons for owned Items'
     );
   }
-  // If it is, retrieve it based on the uuid.
+  // Retrieve the Item from the drop data.
   const item = await Item.fromDropData(data);
 
+  // Only allow macros for Items of type 'feature'
+  if (item.type !== 'feature') {
+    return ui.notifications.warn("Macros can only be created for Feature type items.");
+  }
+
   // Create the macro command using the uuid.
+  // The command will now launch our custom rollItemMacro function.
   const command = `game.smt200x.rollItemMacro("${data.uuid}");`;
   let macro = game.macros.find(
     (m) => m.name === item.name && m.command === command
@@ -776,7 +787,7 @@ function rollItemMacro(itemUuid) {
   };
   // Load the item from the uuid.
   Item.fromDropData(dropData).then((item) => {
-    // Determine if the item loaded and if it's an owned item.
+    // Ensure the item exists and is owned.
     if (!item || !item.parent) {
       const itemName = item?.name ?? itemUuid;
       return ui.notifications.warn(
@@ -784,8 +795,31 @@ function rollItemMacro(itemUuid) {
       );
     }
 
-    // Trigger the item roll
-    item.roll();
+    // Create a dialog to choose which roll to execute.
+    new Dialog({
+      title: item.name,
+      content: `<p>Choose an action:</p>`,
+      buttons: {
+        check: {
+          icon: '<i class="fas fa-dice"></i>',
+          label: "Roll Check",
+          callback: () => {
+            // For a check roll, you could invoke the method for a check.
+            // Based on your sheet code, that might be something like rollSplitD100(true)
+            item.rollSplitD100(true);
+          }
+        },
+        power: {
+          icon: '<i class="fas fa-bolt"></i>',
+          label: "Roll Power",
+          callback: () => {
+            // For a power roll, invoke the power roll
+            item.rollPower(true);
+          }
+        }
+      },
+      default: "check"
+    }).render(true);
   });
 }
 

--- a/module/smt-200x.mjs
+++ b/module/smt-200x.mjs
@@ -1148,6 +1148,7 @@ Hooks.once("canvasReady", () => {
         }
 
         if (data.status) {
+          // TODO: Check actor's Null affinity for that BS?
           token.actor.applyBS(data.status);
           return
         }

--- a/system.json
+++ b/system.json
@@ -20,7 +20,7 @@
       "thumbnail": "systems/smt-200x/assets/anvil-impact.png"
     }
   ],
-  "version": "0.878",
+  "version": "0.881",
   "compatibility": {
     "minimum": 12,
     "verified": "12.331"
@@ -50,7 +50,7 @@
   "packFolders": [],
   "socket": true,
   "manifest": "https://github.com/Alondaar/smt-200x/raw/main/system.json",
-  "download": "https://github.com/Alondaar/smt-200x/archive/refs/tags/release-028.zip",
+  "download": "https://github.com/Alondaar/smt-200x/archive/refs/tags/release-029.zip",
   "background": "systems/smt-200x/assets/anvil-impact.png",
   "gridDistance": 2,
   "gridUnits": "m",

--- a/templates/actor/actor-character-sheet.hbs
+++ b/templates/actor/actor-character-sheet.hbs
@@ -340,38 +340,40 @@
             <input type="text" name="system.contacts" class="grid-span-3" value="{{system.contacts}}" />
           </div>
 
-          <div class="grid grid-12col">
+          <div class="flexcol">
+            <label for="system.alignment" class="resource-label">Alignment</label>
+            <input type="text" name="system.alignment" value="{{system.alignment}}" />
+          </div>
+
+          <div class="grid grid-4col">
             <label for="system.law" class="resource-label">Law</label>
             <input type="text" name="system.law" value="{{system.law}}" data-dtype="Number" />
-            <label for="system.chaos" class="resource-label">Chaos</label>
-            <input type="text" name="system.chaos" value="{{system.chaos}}" data-dtype="Number" />
+            <input type="text" name="system.light" value="{{system.light}}" data-dtype="Number" />
+            <label for="system.light" class="resource-label">Light</label>
+
             <label for="system.neutral" class="resource-label">Neutral</label>
             <input type="text" name="system.neutral" value="{{system.neutral}}" data-dtype="Number" />
-            <label for="system.light" class="resource-label">Light</label>
-            <input type="text" name="system.light" value="{{system.light}}" data-dtype="Number" />
-            <label for="system.dark" class="resource-label">Dark</label>
-            <input type="text" name="system.dark" value="{{system.dark}}" data-dtype="Number" />
-            <label for="system.heeho" class="resource-label">Hee-ho</label>
             <input type="text" name="system.heeho" value="{{system.heeho}}" data-dtype="Number" />
+            <label for="system.heeho" class="resource-label">Hee-ho</label>
+
+            <label for="system.chaos" class="resource-label">Chaos</label>
+            <input type="text" name="system.chaos" value="{{system.chaos}}" data-dtype="Number" />
+            <input type="text" name="system.dark" value="{{system.dark}}" data-dtype="Number" />
+            <label for="system.dark" class="resource-label">Dark</label>
           </div>
 
           <div class="flexrow">
-            <div class="flexcol">
-              <label for="system.alignment" class="resource-label">Alignment</label>
-              <input type="text" name="system.alignment" value="{{system.alignment}}" />
-            </div>
-
             <div class="flexcol">
               <label for="system.macca" class="resource-label">Held Macca</label>
               <input type="text" name="system.macca" value="{{system.macca}}" data-dtype="Number" />
             </div>
           </div>
         </div>
-        <img class="profile-img" src="{{actor.img}}" data-edit="img" title="{{actor.name}}" style="height: 300px" />
+        <div>
+          {{!-- Editors must receive enriched text data from getData to properly handle rolls --}}
+          {{editor enrichedBiography target="system.biography" engine="prosemirror" button=true editable=editable}}
+        </div>
       </div>
-      <hr>
-      {{!-- Editors must receive enriched text data from getData to properly handle rolls --}}
-      {{editor enrichedBiography target="system.biography" engine="prosemirror" button=true editable=editable}}
     </div>
 
 

--- a/templates/actor/actor-character-sheet.hbs
+++ b/templates/actor/actor-character-sheet.hbs
@@ -207,9 +207,9 @@
   {{!-- Sheet Tab Navigation --}}
   <nav class="sheet-tabs tabs" data-group="primary">
     {{!-- Default tab is specified in actor-sheet.mjs --}}
-    <a class="item" data-tab="features">Features</a>
+    <a class="item" data-tab="features">Actions</a>
     <a class="item" data-tab="items">Items</a>
-    <a class="item" data-tab="description">Description</a>
+    <a class="item" data-tab="description">About</a>
     <a class="item" data-tab="effects">Options</a>
   </nav>
 

--- a/templates/actor/parts/actor-features.hbs
+++ b/templates/actor/parts/actor-features.hbs
@@ -1,17 +1,13 @@
 <ol class='items-list'>
   <li class='item flexrow items-header'>
     <div class='item-name flex3'>Actions / Skills</div>
-    <div class='item-prop'>Type</div>
     <div class='item-prop'>Cost</div>
     <div class='item-prop'>Target</div>
-    {{#if system.aux.showTCheaders}}
     <div class='item-prop'>TN</div>
     <div class='item-prop'>Power</div>
+    {{#if system.aux.showTCheaders}}
     <div class='item-prop'>Element</div>
     {{else}}
-    <div class='item-prop'>Wep</div>
-    <div class='item-prop'>TN</div>
-    <div class='item-prop'>Power</div>
     <div class='item-prop'>Affinity</div>
     {{/if}}
     <div class='item-controls flex0'>
@@ -21,63 +17,62 @@
     </div>
   </li>
   {{#each features as |item id|}}
-  <li class='item flexrow' class='align-items: center;' data-item-id='{{item._id}}'>
-    <div class='item-name flex3'>
-      <div class='item-image'>
-        <a class='rollable' data-roll-type='item'>
-          <img src='{{item.img}}' title='{{item.name}}' width='24' height='24' />
-        </a>
-      </div>
-      <h4 class="flexrow">
-        <span class="pip-row">
-          {{range 1 item.system.uses.max item.system.uses.value}}
-        </span>
-        <span style="font-weight: bold;">{{item.name}}</span>
-      </h4>
+  <!-- Main Feature Row -->
+  <li class='item flexrow' data-item-id='{{item._id}}'>
+    <div class='item-main flexrow flex2'>
+      <img class="rollable flex0" style="margin-right: 6px;" data-roll-type='item' src='{{item.img}}'
+        title='{{item.name}}' width='24' height='24' />
+      <span class="pip-row flex0">
+        {{range 1 item.system.uses.max item.system.uses.value}}
+      </span>
+      <span class="clickable toggle-details" style="font-weight:bold; margin: auto;">{{item.name}}</span>
     </div>
-    <div class='item-prop'>{{item.system.type}}</div>
-    <div class='item-control item-prop clickable pay-cost'>{{item.system.cost}}</div>
+    <div class='item-prop cost-prop'>{{item.system.cost}}</div>
     <div class='item-prop'>{{item.system.target}}</div>
     {{#if showTC}}
+    <!-- Additional TC-related columns go here -->
     {{else}}
-    <div class='item-prop clickable weapon-rotate'>{{localize (lookup @root.config.weaponChoices item.system.wep)}}
-    </div>
-    {{/if}}
-    {{#ifNumber item.system.calcTN}}
-    <div class="item-prop">
-      <span class="clickable roll-tn" style="padding: 0 4px;">
-        {{item.system.displayTN}}
-      </span>
-      {{#if item.system.disableMultiaction}}
-      {{else}}
+    <div class='item-prop tn-prop'>
+      {{#ifNumber item.system.calcTN}}
+      <span class="clickable roll-tn" style="padding: 0 4px;">{{item.system.displayTN}}</span>
+      {{#unless item.system.disableMultiaction}}
       <span class="clickable roll-tn-2" style="padding: 0 4px;">
         <i
-          class=" fa-solid fa-circle-2 {{#ifOver item.system.calcTN 99}}{{else}}smtx-multi-action-disabled{{/ifOver}}"></i>
+          class="fa-solid fa-circle-2 {{#ifOver item.system.calcTN 99}}{{else}}smtx-multi-action-disabled{{/ifOver}}"></i>
       </span>
       <span class="clickable roll-tn-3 {{#ifOver item.system.calcTN 199}}{{else}}smtx-multi-action-disabled{{/ifOver}}"
         style="padding: 0 4px;">
         <i class="fa-solid fa-circle-3"></i>
       </span>
-      {{/if}}
+      {{/unless}}
+      {{else}}
+      <span class="clickable roll-tn">{{item.system.displayTN}}</span>
+      {{/ifNumber}}
     </div>
-    {{else}}
-    <div class="item-prop clickable roll-tn">
-      {{item.system.displayTN}}
-    </div>
-    {{/ifNumber}}
     <div class='item-prop clickable roll-power'>{{item.system.calcPower}}</div>
     <div class='item-prop'>{{localize (lookup @root.config.affinities item.system.affinity)}}</div>
-    <div class='item-controls flex0'>
-      <a class='item-control item-edit' title='{{localize "DOCUMENT.Edit" type=' feature'}}'>
+    {{/if}}
+    <div class='item-controls flexrow flex0'>
+      <a class='item-control item-edit' title='{{localize "DOCUMENT.Edit" type=" feature"}}'>
         <i class='fas fa-edit'></i>
       </a>
-      <a class='item-control item-delete' title='{{localize "DOCUMENT.Delete" type=' feature'}}'>
+      <a class='item-control item-delete' title='{{localize "DOCUMENT.Delete" type=" feature"}}'>
         <i class='fas fa-trash'></i>
       </a>
     </div>
   </li>
-  <div class='item-prop'
-    style="text-align:left; padding:4px; border-bottom: 1px solid #c9c7b8 ;margin-bottom: 4px; justify-content: left;">
-    {{item.system.shortEffect}}</div>
+  <!-- Hidden Details Row -->
+  <li class="item item-details" data-item-id='{{item._id}}' style="display:none; margin-left: 2em;">
+    <div class="grid grid-4col">
+      <div>
+        <span style="font-weight: bold;">Type:</span>&nbsp;<span>{{item.system.type}}</span>
+      </div>
+      <div class='clickable weapon-rotate'><span style="font-weight: bold;">
+          Using Weapon:</span>&nbsp; {{localize (lookup @root.config.weaponChoices
+        item.system.wep)}}
+      </div>
+    </div>
+    <div class='flex3' style="text-align: left;">{{item.system.shortEffect}}</div>
+  </li>
   {{/each}}
 </ol>

--- a/templates/actor/parts/actor-features.hbs
+++ b/templates/actor/parts/actor-features.hbs
@@ -1,26 +1,3 @@
-<!-- <div class="grid grid-4col">
-  {{#each effects.temporary.effects as |effect|}}
-  <div class="item flexrow" data-effect-id="{{effect.id}}" data-parent-id="{{effect.parent.id}}">
-    <div class='item-name flexrow'>
-      <img class="item-image flex0" src="{{effect.img}}" width='24' height='24' />
-      &nbsp;
-      <span>{{effect.name}}</span>
-    </div>
-    <div class="item-controls effect-controls flexrow">
-      <a class="effect-control" data-action="toggle" title="{{localize 'SMT_X.Effect.Toggle'}}">
-        <i class="fas {{#if effect.disabled}}fa-check{{else}}fa-times{{/if}}"></i>
-      </a>
-      <a class="effect-control" data-action="edit" title="{{localize 'DOCUMENT.Update' type=" Effect"}}">
-        <i class="fas fa-edit"></i>
-      </a>
-      <a class="effect-control" data-action="delete" title="{{localize 'DOCUMENT.Delete' type=" Effect"}}">
-        <i class="fas fa-trash"></i>
-      </a>
-    </div>
-  </div>
-  {{/each}}
-</div> -->
-
 <ol class='items-list'>
   <li class='item flexrow items-header'>
     <div class='item-name flex3'>Actions / Skills</div>


### PR DESCRIPTION
## v0.881
- Renamed the "Features" tab to "Actions"
- Renamed the "Description" tab to "About"
  - Removed the large actor portrait in the About tab and moved the rich-text field there (WIP)
- The Actions tab for PC actor sheets is now greatly condensed
  - Click on the NAME of the action to expand it, showing the skill type, description, and the weapon-toggling widget
- Dragging Feature items to the macro hotbar now create a useful macro. When used, it will show a prompt allowing you to roll a Check or its Power
- Dragging an item from a compendium no longer displays a warning about Active Effects
- Fixed a critical bug related to NaN (and similar) error handling, which was causing major issues in both consumable items and feature items