### PR TITLE
v0.884

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,9 @@ packs/system-macros/LOG.old
 packs/system-macros/LOG
 packs/system-macros/CURRENT
 packs/system-macros/*.log
+packs/system-effects/
+packs/system-effects/MANIFEST*
+packs/system-effects/LOG.old
+packs/system-effects/LOG
+packs/system-effects/CURRENT
+packs/system-effects/*.log

--- a/css/smt-200x.css
+++ b/css/smt-200x.css
@@ -586,7 +586,15 @@
   font-weight: bold;
 }
 
-
 .smtx-multi-action-disabled {
   opacity: 0.5 !important;
+}
+
+/* For the Buff Widget fields*/
+.green-tint {
+  background-color: rgba(0, 255, 0, 0.2) !important;
+}
+
+.red-tint {
+  background-color: rgba(255, 0, 0, 0.2) !important;
 }

--- a/css/smt-200x.css
+++ b/css/smt-200x.css
@@ -428,8 +428,6 @@
 
 
 .pip-row {
-  display: flex;
-  gap: 4px;
   min-height: 20px;
   margin-top: auto;
   margin-bottom: auto;
@@ -438,17 +436,12 @@
 
 .pip {
   width: 13px;
-  /* Set square size */
   height: 13px;
   border: 2px solid #333;
-  /* Black border for unfilled pips */
   background-color: transparent;
   border-radius: 25%;
-  /* Unfilled pips are transparent */
-  display: inline-block;
   cursor: pointer;
-  transition: background-color 0.2s ease;
-  /* Smooth fill transition */
+  display: inline-block;
 }
 
 .pip.filled {
@@ -456,6 +449,7 @@
   /* Filled pips have black background */
 }
 
+/* this doesn't do anything */
 .pip:hover {
   color: orange;
 }

--- a/css/smt-200x.css
+++ b/css/smt-200x.css
@@ -428,20 +428,23 @@
 
 
 .pip-row {
-  min-height: 20px;
+  display: inline-flex;
+  align-items: center;
   margin-top: auto;
   margin-bottom: auto;
-  margin-right: 6px;
+  margin-right: 4px;
 }
 
 .pip {
   width: 13px;
   height: 13px;
+  /*margin-top: auto;
+  margin-bottom: auto;*/
+  margin-right: 2px;
   border: 2px solid #333;
   background-color: transparent;
   border-radius: 25%;
   cursor: pointer;
-  display: inline-block;
 }
 
 .pip.filled {

--- a/lang/en.json
+++ b/lang/en.json
@@ -83,6 +83,14 @@
       "drain": "Drain",
       "repel": "Repel"
     },
+    "CharAffinityShort": {
+      "normal": "-",
+      "resist": "Rs",
+      "weak": "Wk",
+      "null": "Nu",
+      "drain": "Dn",
+      "repel": "Rp"
+    },
     "AffinityBS": {
       "DEAD": "DEAD",
       "STONE": "STONE",

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -432,9 +432,9 @@ export class SMTXActor extends Actor {
     const mpFormula = this.parseFormula(game.settings.get("smt-200x", "mpFormula"), systemData);
     const fateFormula = this.parseFormula(game.settings.get("smt-200x", "fateFormula"), systemData);
 
-    const hpMod = this.parseFormula(systemData.hp?.maxMod ? systemData.hp.maxMod : 0, systemData);
-    const mpMod = this.parseFormula(systemData.mp?.maxMod ? systemData.mp.maxMod : 0, systemData);
-    const fateMod = this.parseFormula(systemData.fate?.maxMod ? systemData.fate.maxMod : 0, systemData);
+    const hpMod = this.parseFormula(systemData.hp.maxMod != undefined ? systemData.hp.maxMod : "0", systemData);
+    const mpMod = this.parseFormula(systemData.mp.maxMod != undefined ? systemData.mp.maxMod : "0", systemData);
+    const fateMod = this.parseFormula(systemData.fate.maxMod != undefined ? systemData.fate.maxMod : "0", systemData);
 
     systemData.hp.max = ((hpFormula) * systemData.hp.mult) + (hpMod);
     systemData.mp.max = ((mpFormula) * systemData.mp.mult) + (mpMod);
@@ -488,6 +488,9 @@ export class SMTXActor extends Actor {
 
 
   parseFormula(formula, systemData) {
+    if (!isNaN(formula))
+      formula = formula.toString();
+
     try {
       const result = new Roll(formula, systemData).evaluateSync({ minimize: true }).total;
       return result;

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -806,13 +806,10 @@ export class SMTXActor extends Actor {
       "NONE": 999
     };
 
-
     if (removeStatus != "NONE") {
-      console.log(removeStatus)
       this.toggleStatusEffect(removeStatus, { active: false })
       return;
     }
-
 
     const currentPriorityBS = priority[this.system.badStatus];
     const incomingPriorityBS = priority[status];

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -866,7 +866,7 @@ export class SMTXActor extends Actor {
     const fateCost = Math.floor(Math.abs(new Roll(item.system.fateCost, rollData).evaluateSync({ minimize: true }).total));
     const ammoCost = Math.floor(Math.abs(new Roll(item.system.ammoCost, rollData).evaluateSync({ minimize: true }).total));
 
-    // Handle ammo consumption if required.
+    // Handle ammo consumption
     if (ammoCost > 0) {
       if (item.system.wep === "x")
         return ui.notifications.info(`You do not have a weapon equipped.`)
@@ -886,9 +886,8 @@ export class SMTXActor extends Actor {
       }
     }
 
-    // Check that the actor can pay the cost (adjust as needed for HP, if required)
+    // Check that the actor can pay the cost
     if (currentMP - mpCost >= 0 && currentFate - fateCost >= 0) {
-      // Update the actor's resources.
       this.update({
         "system.hp.value": currentHP - hpCost,
         "system.mp.value": currentMP - mpCost,
@@ -901,11 +900,8 @@ export class SMTXActor extends Actor {
       if (mpCost > 0) costs.push(`MP: ${mpCost}`);
       if (fateCost > 0) costs.push(`Fate: ${fateCost}`);
       if (ammoCost > 0) costs.push(`Ammo: ${ammoCost}`);
-
-      // Join the costs with commas
       const costText = costs.join(', ');
 
-      // Create a chat message displaying the costs paid in a slim, comma-separated format.
       const speaker = ChatMessage.getSpeaker({ actor: this.actor });
       const rollMode = game.settings.get("core", "rollMode");
       const flavor = `<strong>Paid for ${item.name}</strong>`;

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -432,9 +432,13 @@ export class SMTXActor extends Actor {
     const mpFormula = this.parseFormula(game.settings.get("smt-200x", "mpFormula"), systemData);
     const fateFormula = this.parseFormula(game.settings.get("smt-200x", "fateFormula"), systemData);
 
-    systemData.hp.max = (hpFormula) * systemData.hp.mult;
-    systemData.mp.max = (mpFormula) * systemData.mp.mult;
-    systemData.fate.max = fateFormula + (systemData.fate?.maxMod ? systemData.fate.maxMod : 0);
+    const hpMod = this.parseFormula(systemData.hp?.maxMod ? systemData.hp.maxMod : 0, systemData);
+    const mpMod = this.parseFormula(systemData.mp?.maxMod ? systemData.mp.maxMod : 0, systemData);
+    const fateMod = this.parseFormula(systemData.fate?.maxMod ? systemData.fate.maxMod : 0, systemData);
+
+    systemData.hp.max = ((hpFormula) * systemData.hp.mult) + (hpMod);
+    systemData.mp.max = ((mpFormula) * systemData.mp.mult) + (mpMod);
+    systemData.fate.max = (fateFormula) + (fateMod);
 
     if (systemData.isBoss) {
       systemData.hp.max *= 5;

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -312,7 +312,7 @@ export class SMTXItem extends Item {
     const descriptionContent = `${item.system.shortEffect}`;
 
     let statusDisplay = ``;
-    if (systemData.appliesBadStatus != "NONE") {
+    if (systemData.appliesBadStatus != "NONE" && systemData.appliesBadStatus != "hpCut" && systemData.appliesBadStatus != "hpSet") {
       // Create a draggable HTML snippet that shows the effect's name.
       statusDisplay = `<div class="draggable-status flex-center align-center" draggable="true" data-status="${systemData.appliesBadStatus}" style="border: 1px dashed #888; padding: 4px; margin: auto; cursor:move; background-color:PeachPuff; font-weight: bold;" title="Drag this onto an Actor or Token to apply the effect.">
         ${systemData.badStatusChance}% ${systemData.appliesBadStatus}
@@ -1099,7 +1099,7 @@ export class SMTXItem extends Item {
     ${(systemData.appliesBadStatus != "NONE" && result.rawBSchance > 0)
           ? `<div>${result.ailmentChance}% ${systemData.appliesBadStatus} (Roll: ${result.ailmentRoll})</div>`
           : ""}  
-    ${(systemData.hpCut > 0)
+    ${(systemData.hpCut > 0 && systemData.appliesBadStatus == "hpCut")
           ? `<div class="flexrow"><span class="flex3">HP cut to ${Math.floor(systemData.hpCut * 100)}% ! (${currentToken.actor.system.hp.value} -> ${Math.floor(currentToken.actor.system.hp.value * systemData.hpCut)})</span>
             <button class="apply-damage-btn smtx-roll-button" title="Apply Damage" 
               data-token-id="${result.tokenId}"
@@ -1109,7 +1109,7 @@ export class SMTXItem extends Item {
             >CUT</button>
           </div>`
           : ""}
-    ${(systemData.hpSet)
+    ${(systemData.hpSet && systemData.appliesBadStatus == "hpSet")
           ? `<div class="flexrow"><span class="flex3">HP set to ${systemData.hpSet == -1 ? `Full` : systemData.hpSet} !!</span>
             <button class="apply-damage-btn smtx-roll-button" title="Apply Damage" 
               data-token-id="${result.tokenId}"

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1538,6 +1538,19 @@ Hooks.on('renderChatMessage', (message, html, data) => {
     const useTugOfWar = game.settings.get("smt-200x", "tugOfWarBuffs");
     const tugOfWarMin = game.settings.get("smt-200x", "tugOfWarMin");
     const tugOfWarMax = game.settings.get("smt-200x", "tugOfWarMax");
+    const noMakakaja = game.settings.get("smt-200x", "taruOnly");
+
+    // Just divert Maka to Taru
+    if (noMakakaja) {
+      if (applyBuffsTo.makakaja) {
+        applyBuffsTo.tarukaja = true
+        applyBuffsTo.makakaja = false
+      }
+      if (applyBuffsTo.makunda) {
+        applyBuffsTo.tarunda = true
+        applyBuffsTo.makunda = false
+      }
+    }
 
     if (useTugOfWar) {
       // Tug of War Buffs

--- a/module/helpers/config.mjs
+++ b/module/helpers/config.mjs
@@ -139,6 +139,25 @@ SMT_X.badStatusList = {
   BS: "SMT_X.AffinityBS.BS"
 }
 
+SMT_X.badStatusChoices = {
+  NONE: "SMT_X.AffinityBS.NONE",
+  DEAD: "SMT_X.AffinityBS.DEAD",
+  STONE: "SMT_X.AffinityBS.STONE",
+  FLY: "SMT_X.AffinityBS.FLY",
+  PARALYZE: "SMT_X.AffinityBS.PARALYZE",
+  CHARM: "SMT_X.AffinityBS.CHARM",
+  POISON: "SMT_X.AffinityBS.POISON",
+  CLOSE: "SMT_X.AffinityBS.CLOSE",
+  BIND: "SMT_X.AffinityBS.BIND",
+  FREEZE: "SMT_X.AffinityBS.FREEZE",
+  SLEEP: "SMT_X.AffinityBS.SLEEP",
+  PANIC: "SMT_X.AffinityBS.PANIC",
+  SHOCK: "SMT_X.AffinityBS.SHOCK",
+  HAPPY: "SMT_X.AffinityBS.HAPPY",
+  hpCut: "HP Cut",
+  hpSet: "HP Set"
+}
+
 SMT_X.gems = {
   diamond: "SMT.gems.diamond",
   pearl: "SMT.gems.pearl",
@@ -222,4 +241,22 @@ SMT_X.badStatusList_TC = {
   SHOCK: "SMT_X.AffinityBS_TC.SHOCK",
   HAPPY: "SMT_X.AffinityBS_TC.HAPPY",
   BS: "SMT_X.AffinityBS_TC.BS"
+}
+
+SMT_X.badStatusChoices_TC = {
+  NONE: "SMT_X.AffinityBS_TC.NONE",
+  DEAD: "SMT_X.AffinityBS_TC.DEAD",
+  STONE: "SMT_X.AffinityBS_TC.STONE",
+  FLY: "SMT_X.AffinityBS_TC.FLY",
+  PARALYZE: "SMT_X.AffinityBS_TC.PARALYZE",
+  CHARM: "SMT_X.AffinityBS_TC.CHARM",
+  POISON: "SMT_X.AffinityBS_TC.POISON",
+  CLOSE: "SMT_X.AffinityBS_TC.CLOSE",
+  BIND: "SMT_X.AffinityBS_TC.BIND",
+  FREEZE: "SMT_X.AffinityBS_TC.FREEZE",
+  SLEEP: "SMT_X.AffinityBS_TC.SLEEP",
+  PANIC: "SMT_X.AffinityBS_TC.PANIC",
+  SHOCK: "SMT_X.AffinityBS_TC.SHOCK",
+  hpCut: "HP Cut",
+  hpSet: "HP Set"
 }

--- a/module/helpers/config.mjs
+++ b/module/helpers/config.mjs
@@ -79,9 +79,18 @@ SMT_X.charAffinityIcons = {
   normal: "-",
   resist: "fa-shield-halved",
   weak: "fa-burst",
-  null: "fa-shield",
+  null: `<i class="fa-solid fa-shield"></i>`,
   drain: "fa-shield-heart",
   repel: "fa-shield-virus"
+};
+
+SMT_X.charAffinityAbbr = {
+  normal: "SMT_X.CharAffinityShort.normal",
+  resist: "SMT_X.CharAffinityShort.resist",
+  weak: "SMT_X.CharAffinityShort.weak",
+  null: "SMT_X.CharAffinityShort.null",
+  drain: "SMT_X.CharAffinityShort.drain",
+  repel: "SMT_X.CharAffinityShort.repel"
 };
 
 SMT_X.affinities = {

--- a/module/helpers/config.mjs
+++ b/module/helpers/config.mjs
@@ -60,6 +60,30 @@ SMT_X.powerDice = {
   spell: 'Spell',
 };
 
+SMT_X.affinityIcons = {
+  strike: "icons/skills/melee/blade-tip-orange.webp",
+  gun: "icons/skills/ranged/cannon-barrel-firing-yellow.webp",
+  fire: "icons/magic/fire/projectile-fireball-smoke-strong-orange.webp",
+  ice: "icons/magic/water/barrier-ice-crystal-wall-faceted-light.webp",
+  elec: "icons/magic/lightning/bolt-strike-streak-yellow.webp",
+  force: "icons/magic/air/air-burst-spiral-teal-green.webp",
+  expel: "icons/magic/light/explosion-star-glow-orange.webp",
+  death: "icons/magic/death/skull-energy-light-purple.webp",
+  mind: "icons/skills/wounds/anatomy-organ-brain-pink-red.webp",
+  nerve: "icons/magic/control/debuff-chains-ropes-net-white.webp",
+  curse: "icons/magic/unholy/energy-smoke-pink.webp",
+  magic: "icons/magic/symbols/triangle-glowing-green.webp"
+};
+
+SMT_X.charAffinityIcons = {
+  normal: "-",
+  resist: "fa-shield-halved",
+  weak: "fa-burst",
+  null: "fa-shield",
+  drain: "fa-shield-heart",
+  repel: "fa-shield-virus"
+};
+
 SMT_X.affinities = {
   strike: 'SMT_X.Affinity.strike',
   gun: 'SMT_X.Affinity.gun',

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -192,76 +192,7 @@ export class SMTXActorSheet extends ActorSheet {
 
     html.on('click', '.pay-cost', (ev) => {
       const li = $(ev.currentTarget).parents('.item');
-      const item = this.actor.items.get(li.data('itemId'));
-      const rollData = this.actor.getRollData();
-
-      // Retrieve current resource values
-      const currentHP = this.actor.system.hp.value;
-      const currentMP = this.actor.system.mp.value;
-      const currentFate = this.actor.system.fate.value;
-
-      // Calculate cost values using Roll formulas
-      const hpCost = Math.floor(Math.abs(new Roll(item.system.hpCost, rollData).evaluateSync({ minimize: true }).total));
-      const mpCost = Math.floor(Math.abs(new Roll(item.system.mpCost, rollData).evaluateSync({ minimize: true }).total));
-      const fateCost = Math.floor(Math.abs(new Roll(item.system.fateCost, rollData).evaluateSync({ minimize: true }).total));
-      const ammoCost = Math.floor(Math.abs(new Roll(item.system.ammoCost, rollData).evaluateSync({ minimize: true }).total));
-
-      // Handle ammo consumption if required.
-      if (ammoCost > 0) {
-        if (item.system.wep === "x") {
-          ui.notifications.info(`You do not have a weapon equipped.`);
-          return;
-        }
-        if (item.system.wep === "a") {
-          if (this.actor.system.wepA.ammo - ammoCost >= 0) {
-            this.actor.update({ "system.wepA.ammo": this.actor.system.wepA.ammo - ammoCost });
-          } else {
-            ui.notifications.info(`You do not have enough ammo.`);
-            return;
-          }
-        } else {
-          if (this.actor.system.wepB.ammo - ammoCost >= 0) {
-            this.actor.update({ "system.wepB.ammo": this.actor.system.wepB.ammo - ammoCost });
-          } else {
-            ui.notifications.info(`You do not have enough ammo.`);
-            return;
-          }
-        }
-      }
-
-      // Check that the actor can pay the cost (adjust as needed for HP, if required)
-      if (currentMP - mpCost >= 0 && currentFate - fateCost >= 0) {
-        // Update the actor's resources.
-        this.actor.update({
-          "system.hp.value": currentHP - hpCost,
-          "system.mp.value": currentMP - mpCost,
-          "system.fate.value": currentFate - fateCost
-        });
-
-        // Build a list of cost items that are greater than 0.
-        const costs = [];
-        if (hpCost > 0) costs.push(`HP: ${hpCost}`);
-        if (mpCost > 0) costs.push(`MP: ${mpCost}`);
-        if (fateCost > 0) costs.push(`Fate: ${fateCost}`);
-        if (ammoCost > 0) costs.push(`Ammo: ${ammoCost}`);
-
-        // Join the costs with commas
-        const costText = costs.join(', ');
-
-        // Create a chat message displaying the costs paid in a slim, comma-separated format.
-        const speaker = ChatMessage.getSpeaker({ actor: this.actor });
-        const rollMode = game.settings.get("core", "rollMode");
-        const flavor = `<strong>Paid for ${item.name}</strong>`;
-
-        ChatMessage.create({
-          speaker: speaker,
-          rollMode: rollMode,
-          flavor: flavor,
-          content: `<div class="pay-cost-message">${costText}</div>`
-        });
-      } else {
-        ui.notifications.info(`You are unable to pay the cost for that skill.`);
-      }
+      this.actor.payCost(li.data('itemId'));
     });
 
 

--- a/module/smt-200x.mjs
+++ b/module/smt-200x.mjs
@@ -1164,11 +1164,10 @@ class BuffEffectsWidget extends Application {
     const disposition = (this.mode === "friendly") ? 1 : -1;
     const tokens = scene.tokens.filter(t => t.disposition === disposition);
 
-    // Example: updates to actor data
+
     for (let token of tokens) {
       let updates = {};
 
-      // e.g. tarukaja => taru
       updates["system.buffs.taru"] = effects.tarukaja.amount;
       updates["system.buffs.maka"] = effects.makakaja.amount;
       updates["system.buffs.raku"] = effects.rakukaja.amount;

--- a/module/smt-200x.mjs
+++ b/module/smt-200x.mjs
@@ -642,9 +642,9 @@ Handlebars.registerHelper('range', function (start, end, options) {
   `;
   }
 
-  if (end >= start) {
-    result = `<div style="width: ${end * 14.5}px; margin-top: auto;>` + result + `</div>`
-  }
+  /*if (end >= start) {
+    result = `<div style="width: ${end * 17.5}px; margin-top: auto;>` + result + `</div>`
+  }*/
 
   return new Handlebars.SafeString(result);
 });

--- a/module/smt-200x.mjs
+++ b/module/smt-200x.mjs
@@ -638,8 +638,12 @@ Handlebars.registerHelper('range', function (start, end, options) {
 
   for (let i = start; i <= end; i++) {
     result += `
-  <div class="pip${i <= options ? " filled" : ""}" data-index="${i}"></div>
+  <span class="pip${i <= options ? " filled" : ""}" data-index="${i}"></span>
   `;
+  }
+
+  if (end >= start) {
+    result = `<div style="width: ${end * 14.5}px; margin-top: auto;>` + result + `</div>`
   }
 
   return new Handlebars.SafeString(result);

--- a/module/smt-200x.mjs
+++ b/module/smt-200x.mjs
@@ -81,19 +81,6 @@ Hooks.once('init', function () {
   });
 
 
-  // Extend the built-in status effects with your custom conditions.
-  /*CONFIG.statusEffects = CONFIG.statusEffects.concat([
-    {
-      id: "DEAD",
-      img: "icons/svg/skull.svg",
-      label: "Dead"
-    },
-    {
-      id: "POISON",
-      img: "icons/svg/acid.svg",
-      label: "Poisoned"
-    },
-  ]);*/
 
   // Overrides the statuses
   CONFIG.statusEffects = [

--- a/module/smt-200x.mjs
+++ b/module/smt-200x.mjs
@@ -1125,20 +1125,32 @@ class BuffEffectsWidget extends Application {
   async _dekaja() {
     const settingKey = (this.mode === "friendly") ? "friendlyEffects" : "hostileEffects";
     let effects = game.settings.get("smt-200x", settingKey) || {};
+    let tugOfWar = game.settings.get("smt-200x", "tugOfWarBuffs");
 
-    if (effects.tarukaja.amount > 0) {
+    if (tugOfWar) {
+      if (effects.tarukaja.amount > 0) {
+        effects.tarukaja.amount = 0;
+        effects.tarukaja.count = 0;
+      }
+      if (effects.makakaja.amount > 0) {
+        effects.makakaja.amount = 0;
+        effects.makakaja.count = 0;
+      }
+      if (effects.rakukaja.amount > 0) {
+        effects.rakukaja.amount = 0;
+        effects.rakukaja.count = 0;
+      }
+      if (effects.sukukaja.amount > 0) {
+        effects.sukukaja.amount = 0;
+        effects.sukukaja.count = 0;
+      }
+    } else {
       effects.tarukaja.amount = 0;
       effects.tarukaja.count = 0;
-    }
-    if (effects.makakaja.amount > 0) {
       effects.makakaja.amount = 0;
       effects.makakaja.count = 0;
-    }
-    if (effects.rakukaja.amount > 0) {
       effects.rakukaja.amount = 0;
       effects.rakukaja.count = 0;
-    }
-    if (effects.sukukaja.amount > 0) {
       effects.sukukaja.amount = 0;
       effects.sukukaja.count = 0;
     }
@@ -1173,22 +1185,14 @@ class BuffEffectsWidget extends Application {
         effects.sukukaja.count = 0;
       }
     } else {
-      if (effects.tarunda.amount > 0) {
-        effects.tarunda.amount = 0;
-        effects.tarunda.count = 0;
-      }
-      if (effects.makunda.amount > 0) {
-        effects.makunda.amount = 0;
-        effects.makunda.count = 0;
-      }
-      if (effects.rakunda.amount > 0) {
-        effects.rakunda.amount = 0;
-        effects.rakunda.count = 0;
-      }
-      if (effects.sukunda.amount > 0) {
-        effects.sukunda.amount = 0;
-        effects.sukunda.count = 0;
-      }
+      effects.tarunda.amount = 0;
+      effects.tarunda.count = 0;
+      effects.makunda.amount = 0;
+      effects.makunda.count = 0;
+      effects.rakunda.amount = 0;
+      effects.rakunda.count = 0;
+      effects.sukunda.amount = 0;
+      effects.sukunda.count = 0;
     }
 
 

--- a/module/smt-200x.mjs
+++ b/module/smt-200x.mjs
@@ -71,7 +71,6 @@ Hooks.once('init', function () {
   console.log('SMT 200X | Initializing socket listener for buff widget updates');
   game.socket.on("system.smt-200x", async (data) => {
     if (data.action === "updateBuffWidgets") {
-      // Optionally, you could check data.effects if you want to update game settings directly.
       if (data.mode === "friendly" && game.friendlyEffectsWidget) {
         game.friendlyEffectsWidget.render();
       } else if (data.mode === "hostile" && game.hostileEffectsWidget) {
@@ -1027,25 +1026,21 @@ class BuffEffectsWidget extends Application {
       await this.savePosition();
     });
 
-    // Example: reset button
     html.on("click", ".reset-button", async (ev) => {
       ev.preventDefault();
       await this._resetAllEffects();
     });
 
-    // Example: Dekaja
     html.on("click", ".dekaja-button", async (ev) => {
       ev.preventDefault();
       await this._dekaja();
     });
 
-    // Example: Dekunda
     html.on("click", ".dekunda-button", async (ev) => {
       ev.preventDefault();
       await this._dekunda();
     });
 
-    // Example: numeric inputs
     html.find("input[data-category]").on("change", this._onInputChange.bind(this));
   }
 
@@ -1062,6 +1057,7 @@ class BuffEffectsWidget extends Application {
 
     // Example: If you do Tug of War logic
     data.useTugOfWar = game.settings.get("smt-200x", "tugOfWarBuffs");
+    data.taruOnly = game.settings.get("smt-200x", "taruOnly");
 
     // Example: Summaries
     data.effects.taruTotal = data.effects.tarukaja.amount - data.effects.tarunda.amount;

--- a/module/smt-200x.mjs
+++ b/module/smt-200x.mjs
@@ -670,6 +670,18 @@ Handlebars.registerHelper("showTC", function () {
   return game.settings.get("smt-200x", "showTCheaders");
 });
 
+// For the buff widget
+Handlebars.registerHelper('tint', function (value) {
+  const num = Number(value);
+  if (num > 0) {
+    return "green-tint";
+  } else if (num < 0) {
+    return "red-tint";
+  } else {
+    return ""; // No tint if the value is 0.
+  }
+});
+
 
 /* -------------------------------------------- */
 /*  Ready Hook                                  */
@@ -1129,23 +1141,44 @@ class BuffEffectsWidget extends Application {
   async _dekunda() {
     const settingKey = (this.mode === "friendly") ? "friendlyEffects" : "hostileEffects";
     let effects = game.settings.get("smt-200x", settingKey) || {};
+    let tugOfWar = game.settings.get("smt-200x", "tugOfWarBuffs");
 
-    if (effects.tarunda.amount > 0) {
-      effects.tarunda.amount = 0;
-      effects.tarunda.count = 0;
+    if (tugOfWar) {
+      if (effects.tarukaja.amount < 0) {
+        effects.tarukaja.amount = 0;
+        effects.tarukaja.count = 0;
+      }
+      if (effects.makakaja.amount < 0) {
+        effects.makakaja.amount = 0;
+        effects.makakaja.count = 0;
+      }
+      if (effects.rakukaja.amount < 0) {
+        effects.rakukaja.amount = 0;
+        effects.rakukaja.count = 0;
+      }
+      if (effects.sukukaja.amount < 0) {
+        effects.sukukaja.amount = 0;
+        effects.sukukaja.count = 0;
+      }
+    } else {
+      if (effects.tarunda.amount > 0) {
+        effects.tarunda.amount = 0;
+        effects.tarunda.count = 0;
+      }
+      if (effects.makunda.amount > 0) {
+        effects.makunda.amount = 0;
+        effects.makunda.count = 0;
+      }
+      if (effects.rakunda.amount > 0) {
+        effects.rakunda.amount = 0;
+        effects.rakunda.count = 0;
+      }
+      if (effects.sukunda.amount > 0) {
+        effects.sukunda.amount = 0;
+        effects.sukunda.count = 0;
+      }
     }
-    if (effects.makunda.amount > 0) {
-      effects.makunda.amount = 0;
-      effects.makunda.count = 0;
-    }
-    if (effects.rakunda.amount > 0) {
-      effects.rakunda.amount = 0;
-      effects.rakunda.count = 0;
-    }
-    if (effects.sukunda.amount > 0) {
-      effects.sukunda.amount = 0;
-      effects.sukunda.count = 0;
-    }
+
 
     await game.settings.set("smt-200x", settingKey, effects);
     await this._updateTokens(effects);

--- a/module/smt-200x.mjs
+++ b/module/smt-200x.mjs
@@ -399,7 +399,7 @@ Hooks.once('init', function () {
     default: false
   });
 
-  game.settings.register("smt-200x", "pierceResist", {
+  /*game.settings.register("smt-200x", "pierceResist", {
     name: "Pierce treats Resist/Strong as:",
     hint: "Tells the game how an attack with Pierce enabled treats certain Affinities.",
     scope: "world",
@@ -467,7 +467,7 @@ Hooks.once('init', function () {
       repel: "Repel"
     },
     default: "repel"
-  });
+  });*/
 
   game.settings.register("smt-200x", "showFloatingDamage", {
     name: "Show Floating Damage Text",
@@ -1057,6 +1057,8 @@ class BuffEffectsWidget extends Application {
 
     // Example: If you do Tug of War logic
     data.useTugOfWar = game.settings.get("smt-200x", "tugOfWarBuffs");
+    data.tugMax = game.settings.get("smt-200x", "tugOfWarMax");
+    data.tugMin = game.settings.get("smt-200x", "tugOfWarMin");
     data.taruOnly = game.settings.get("smt-200x", "taruOnly");
 
     // Example: Summaries

--- a/module/smt-200x.mjs
+++ b/module/smt-200x.mjs
@@ -1128,22 +1128,14 @@ class BuffEffectsWidget extends Application {
     let tugOfWar = game.settings.get("smt-200x", "tugOfWarBuffs");
 
     if (tugOfWar) {
-      if (effects.tarukaja.amount > 0) {
+      if (effects.tarukaja.amount > 0)
         effects.tarukaja.amount = 0;
-        effects.tarukaja.count = 0;
-      }
-      if (effects.makakaja.amount > 0) {
+      if (effects.makakaja.amount > 0)
         effects.makakaja.amount = 0;
-        effects.makakaja.count = 0;
-      }
-      if (effects.rakukaja.amount > 0) {
+      if (effects.rakukaja.amount > 0)
         effects.rakukaja.amount = 0;
-        effects.rakukaja.count = 0;
-      }
-      if (effects.sukukaja.amount > 0) {
+      if (effects.sukukaja.amount > 0)
         effects.sukukaja.amount = 0;
-        effects.sukukaja.count = 0;
-      }
     } else {
       effects.tarukaja.amount = 0;
       effects.tarukaja.count = 0;
@@ -1168,22 +1160,14 @@ class BuffEffectsWidget extends Application {
     let tugOfWar = game.settings.get("smt-200x", "tugOfWarBuffs");
 
     if (tugOfWar) {
-      if (effects.tarukaja.amount < 0) {
+      if (effects.tarukaja.amount < 0)
         effects.tarukaja.amount = 0;
-        effects.tarukaja.count = 0;
-      }
-      if (effects.makakaja.amount < 0) {
+      if (effects.makakaja.amount < 0)
         effects.makakaja.amount = 0;
-        effects.makakaja.count = 0;
-      }
-      if (effects.rakukaja.amount < 0) {
+      if (effects.rakukaja.amount < 0)
         effects.rakukaja.amount = 0;
-        effects.rakukaja.count = 0;
-      }
-      if (effects.sukukaja.amount < 0) {
+      if (effects.sukukaja.amount < 0)
         effects.sukukaja.amount = 0;
-        effects.sukukaja.count = 0;
-      }
     } else {
       effects.tarunda.amount = 0;
       effects.tarunda.count = 0;

--- a/system.json
+++ b/system.json
@@ -20,7 +20,7 @@
       "thumbnail": "systems/smt-200x/assets/anvil-impact.png"
     }
   ],
-  "version": "0.882",
+  "version": "0.884",
   "compatibility": {
     "minimum": 12,
     "verified": "12.331"
@@ -57,7 +57,7 @@
   "packFolders": [],
   "socket": true,
   "manifest": "https://github.com/Alondaar/smt-200x/raw/main/system.json",
-  "download": "https://github.com/Alondaar/smt-200x/archive/refs/tags/release-030.zip",
+  "download": "https://github.com/Alondaar/smt-200x/archive/refs/tags/release-031.zip",
   "background": "systems/smt-200x/assets/anvil-impact.png",
   "gridDistance": 2,
   "gridUnits": "m",

--- a/template.json
+++ b/template.json
@@ -236,7 +236,13 @@
       "age": "",
       "class1": "",
       "class2": "",
-      "class3": ""
+      "class3": "",
+      "master": "",
+      "subActors": [],
+      "inheritHP": false,
+      "inheritMP": true,
+      "inheritFate": true,
+      "inheritCurrency": true
     },
     "npc": {
       "templates": [

--- a/template.json
+++ b/template.json
@@ -237,7 +237,7 @@
       "class1": "",
       "class2": "",
       "class3": "",
-      "master": "",
+      "linkedActor": "",
       "subActors": [],
       "inheritHP": false,
       "inheritMP": true,

--- a/templates/actor/actor-character-sheet.hbs
+++ b/templates/actor/actor-character-sheet.hbs
@@ -392,6 +392,17 @@
             <label for="system.hp.mult" class="resource-label">HP Multiplier</label>
             <input type="text" name="system.hp.mult" value="{{system.hp.mult}}" data-dtype="Number" />
           </div>
+        </div>
+      </section>
+
+      <hr>
+
+      <section class="main">
+        <div class="grid grid-6col">
+          <div class="flexcol">
+            <label for="system.hp.mult" class="resource-label">HP Multiplier</label>
+            <input type="text" name="system.hp.mult" value="{{system.hp.mult}}" data-dtype="Number" />
+          </div>
 
           <div class="flexcol">
             <label for="system.mp.mult" class="resource-label">MP Multiplier</label>

--- a/templates/actor/actor-character-sheet.hbs
+++ b/templates/actor/actor-character-sheet.hbs
@@ -384,16 +384,21 @@
         {{> "systems/smt-200x/templates/actor/parts/actor-effects.hbs"}}
       </section>
 
-      <hr>
-
+      <!-- <hr>
       <section class="main">
-        <div class="grid grid-6col">
+        <div class="flexrow">
+          {{#each system.affinity as |aff key|}}
           <div class="flexcol">
-            <label for="system.hp.mult" class="resource-label">HP Multiplier</label>
-            <input type="text" name="system.hp.mult" value="{{system.hp.mult}}" data-dtype="Number" />
+            <div class="affinity-icon-wrapper">
+              <img src="{{lookup @root.config.affinityIcons key}}" alt="{{key}}" height="26" />
+            </div>
+            <select name="system.affinity.{{key}}">
+              {{selectOptions @root.config.charAffinityAbbr selected=aff localize=true}}
+            </select>
           </div>
+          {{/each}}
         </div>
-      </section>
+      </section> -->
 
       <hr>
 

--- a/templates/actor/actor-npc-sheet.hbs
+++ b/templates/actor/actor-npc-sheet.hbs
@@ -243,7 +243,7 @@
   {{!-- Sheet Tab Navigation --}}
   <nav class="sheet-tabs tabs" data-group="primary">
     {{!-- Default tab is specified in actor-sheet.mjs --}}
-    <a class="item" data-tab="features">Features</a>
+    <a class="item" data-tab="features">Actions</a>
     <a class="item" data-tab="effects">Options</a>
   </nav>
 

--- a/templates/actor/parts/actor-effects.hbs
+++ b/templates/actor/parts/actor-effects.hbs
@@ -4,7 +4,7 @@
     <div class="item-name effect-name flexrow">{{localize section.label}}</div>
     <div class="item-controls effect-controls flexrow">
       <a class="effect-control" data-action="create" title="{{localize 'DOCUMENT.Create' type=" Effect"}}">
-        <i class="fas fa-plus"></i> {{localize "DOCUMENT.New" type="Effect"}}
+        <i class="fas fa-plus"></i> <!--{{localize "DOCUMENT.New" type="Effect"}}-->
       </a>
     </div>
   </li>

--- a/templates/actor/parts/actor-features.hbs
+++ b/templates/actor/parts/actor-features.hbs
@@ -20,7 +20,7 @@
   <!-- Main Feature Row -->
   <li class='item flexrow' data-item-id='{{item._id}}'>
     <div class='item-main flexrow flex2'>
-      <img class="rollable flex0" style="margin-right: 6px;" data-roll-type='item' src='{{item.img}}'
+      <img class="rollable flex0" style="margin-top: auto; margin-right: 6px;" data-roll-type='item' src='{{item.img}}'
         title='{{item.name}}' width='24' height='24' />
       <span class="pip-row flex0">
         {{range 1 item.system.uses.max item.system.uses.value}}

--- a/templates/actor/parts/actor-features.hbs
+++ b/templates/actor/parts/actor-features.hbs
@@ -19,13 +19,16 @@
   {{#each features as |item id|}}
   <!-- Main Feature Row -->
   <li class='item flexrow' data-item-id='{{item._id}}'>
-    <div class='item-main flexrow flex2'>
-      <img class="rollable flex0" style="margin-top: auto; margin-right: 6px;" data-roll-type='item' src='{{item.img}}'
-        title='{{item.name}}' width='24' height='24' />
-      <span class="pip-row flex0">
+    <div class='flex2'
+      style="display: inline-flex; flex-wrap: wrap; align-items: center; margin-top: 4px; margin-bottom: 4px;">
+      <img class="rollable" style="margin-top: auto; margin-bottom: auto; margin-right: 6px;" data-roll-type='item'
+        src='{{item.img}}' title='{{item.name}}' width='24' height='24' />
+      <div class="pip-row" style="">
         {{range 1 item.system.uses.max item.system.uses.value}}
-      </span>
-      <span class="clickable toggle-details" style="font-weight:bold; margin: auto;">{{item.name}}</span>
+      </div>
+      <div class="clickable toggle-details" style="font-weight:bold; margin-top: auto; margin-bottom: auto;">
+        {{item.name}}
+      </div>
     </div>
     <div class='item-prop clickable pay-cost'>{{item.system.cost}}</div>
     <div class='item-prop'>{{item.system.target}}</div>

--- a/templates/actor/parts/actor-features.hbs
+++ b/templates/actor/parts/actor-features.hbs
@@ -32,9 +32,6 @@
     </div>
     <div class='item-prop clickable pay-cost'>{{item.system.cost}}</div>
     <div class='item-prop'>{{item.system.target}}</div>
-    {{#if showTC}}
-    <!-- Additional TC-related columns go here -->
-    {{else}}
     <div class='item-prop'>
       {{#ifNumber item.system.calcTN}}
       <span class="clickable roll-tn" style="padding: 0 4px;">{{item.system.displayTN}}</span>
@@ -54,7 +51,6 @@
     </div>
     <div class='item-prop clickable roll-power'>{{item.system.calcPower}}</div>
     <div class='item-prop'>{{localize (lookup @root.config.affinities item.system.affinity)}}</div>
-    {{/if}}
     <div class='item-controls flexrow flex0'>
       <a class='item-control item-edit' title='{{localize "DOCUMENT.Edit" type=" feature"}}'>
         <i class='fas fa-edit'></i>
@@ -75,7 +71,7 @@
         item.system.wep)}}
       </div>
     </div>
-    <div class='flex3' style="text-align: left;">{{item.system.shortEffect}}</div>
+    <div class='flex3' style="text-align: left; margin-bottom: 1em;">{{item.system.shortEffect}}</div>
   </li>
   {{/each}}
 </ol>

--- a/templates/actor/parts/actor-features.hbs
+++ b/templates/actor/parts/actor-features.hbs
@@ -27,12 +27,12 @@
       </span>
       <span class="clickable toggle-details" style="font-weight:bold; margin: auto;">{{item.name}}</span>
     </div>
-    <div class='item-prop cost-prop'>{{item.system.cost}}</div>
+    <div class='item-prop clickable pay-cost'>{{item.system.cost}}</div>
     <div class='item-prop'>{{item.system.target}}</div>
     {{#if showTC}}
     <!-- Additional TC-related columns go here -->
     {{else}}
-    <div class='item-prop tn-prop'>
+    <div class='item-prop'>
       {{#ifNumber item.system.calcTN}}
       <span class="clickable roll-tn" style="padding: 0 4px;">{{item.system.displayTN}}</span>
       {{#unless item.system.disableMultiaction}}

--- a/templates/actor/parts/npc-features.hbs
+++ b/templates/actor/parts/npc-features.hbs
@@ -2,12 +2,15 @@
   <li class='item flexrow items-header'>
     <div class='item-prop roll-d10'>d10</div>
     <div class='item-name'>Actions / Skills</div>
-    <div class='item-prop'>Type</div>
     <div class='item-prop'>Cost</div>
     <div class='item-prop'>Target</div>
     <div class='item-prop'>TN</div>
     <div class='item-prop'>Power</div>
+    {{#if system.aux.showTCheaders}}
+    <div class='item-prop'>Element</div>
+    {{else}}
     <div class='item-prop'>Affinity</div>
+    {{/if}}
     <div class='item-controls'>
       <a class='item-control item-create' title='Create item' data-type='feature'>
         <i class='fas fa-plus'></i>
@@ -15,60 +18,67 @@
     </div>
   </li>
   {{#each features as |item id|}}
-  <li class='item flexrow' class='align-items: center;' data-item-id='{{item._id}}'>
-    <input type="text" name="item.system.actionPattern" class='item-prop actionPattern'
-      value="{{item.system.actionPattern}}">
-    <div class='item-name flex3'>
-      <div class='item-image'>
-        <a class='rollable' data-roll-type='item'>
-          <img src='{{item.img}}' title='{{item.name}}' width='24' height='24' />
-        </a>
-      </div>
-      <h4 class="flexrow">
-        <span class="pip-row">
-          {{range 1 item.system.uses.max item.system.uses.value}}
-        </span>
-        <span>{{item.name}}</span>
-      </h4>
+  <!-- Main Feature Row -->
+  <li class='item flexrow' data-item-id='{{item._id}}'>
+    {{#unless system.aux.showTCheaders}}
+    <div class="item-prop flex0">
+      <input type="text" name="item.system.actionPattern" class='actionPattern' style="width: 50px;"
+        value="{{item.system.actionPattern}}">
     </div>
-    <div class='item-prop'>{{item.system.type}}</div>
-    <div class='item-control item-prop clickable pay-cost'>{{item.system.cost}}</div>
+    {{/unless}}
+    <div class='flex2'
+      style="display: inline-flex; flex-wrap: wrap; align-items: center; margin-top: 4px; margin-bottom: 4px;">
+      <img class="rollable" style="margin-top: auto; margin-bottom: auto; margin-right: 6px;" data-roll-type='item'
+        src='{{item.img}}' title='{{item.name}}' width='24' height='24' />
+      <div class="pip-row" style="">
+        {{range 1 item.system.uses.max item.system.uses.value}}
+      </div>
+      <div class="clickable toggle-details" style="font-weight:bold; margin-top: auto; margin-bottom: auto;">
+        {{item.name}}
+      </div>
+    </div>
+    <div class='item-prop clickable pay-cost'>{{item.system.cost}}</div>
     <div class='item-prop'>{{item.system.target}}</div>
-    {{#ifNumber item.system.calcTN}}
-    <div class="item-prop">
-      <span class="clickable roll-tn" style="padding: 0 4px;">
-        {{item.system.displayTN}}
-      </span>
-      {{#if item.system.disableMultiaction}}
-      {{else}}
+    <div class='item-prop'>
+      {{#ifNumber item.system.calcTN}}
+      <span class="clickable roll-tn" style="padding: 0 4px;">{{item.system.displayTN}}</span>
+      {{#unless item.system.disableMultiaction}}
       <span class="clickable roll-tn-2" style="padding: 0 4px;">
         <i
-          class=" fa-solid fa-circle-2 {{#ifOver item.system.calcTN 99}}{{else}}smtx-multi-action-disabled{{/ifOver}}"></i>
+          class="fa-solid fa-circle-2 {{#ifOver item.system.calcTN 99}}{{else}}smtx-multi-action-disabled{{/ifOver}}"></i>
       </span>
       <span class="clickable roll-tn-3 {{#ifOver item.system.calcTN 199}}{{else}}smtx-multi-action-disabled{{/ifOver}}"
         style="padding: 0 4px;">
         <i class="fa-solid fa-circle-3"></i>
       </span>
-      {{/if}}
+      {{/unless}}
+      {{else}}
+      <span class="clickable roll-tn">{{item.system.displayTN}}</span>
+      {{/ifNumber}}
     </div>
-    {{else}}
-    <div class="item-prop clickable roll-tn">
-      {{item.system.displayTN}}
-    </div>
-    {{/ifNumber}}
     <div class='item-prop clickable roll-power'>{{item.system.calcPower}}</div>
     <div class='item-prop'>{{localize (lookup @root.config.affinities item.system.affinity)}}</div>
-    <div class='item-controls'>
-      <a class='item-control item-edit' title='{{localize "DOCUMENT.Edit" type=' feature'}}'>
+    <div class='item-controls flexrow flex0'>
+      <a class='item-control item-edit' title='{{localize "DOCUMENT.Edit" type=" feature"}}'>
         <i class='fas fa-edit'></i>
       </a>
-      <a class='item-control item-delete' title='{{localize "DOCUMENT.Delete" type=' feature'}}'>
+      <a class='item-control item-delete' title='{{localize "DOCUMENT.Delete" type=" feature"}}'>
         <i class='fas fa-trash'></i>
       </a>
     </div>
   </li>
-  <div class='item-prop'
-    style="text-align:left; padding:4px; border-bottom: 1px solid #c9c7b8 ;margin-bottom: 4px; justify-content: left;">
-    {{item.system.shortEffect}}</div>
+  <!-- Hidden Details Row -->
+  <li class="item item-details" data-item-id='{{item._id}}' style="display:none; margin-left: 2em;">
+    <div class="grid grid-4col">
+      <div>
+        <span style="font-weight: bold;">Type:</span>&nbsp;<span>{{item.system.type}}</span>
+      </div>
+      <div class='clickable weapon-rotate'><span style="font-weight: bold;">
+          Using Weapon:</span>&nbsp; {{localize (lookup @root.config.weaponChoices
+        item.system.wep)}}
+      </div>
+    </div>
+    <div class='flex3' style="text-align: left; margin-bottom: 1em;">{{item.system.shortEffect}}</div>
+  </li>
   {{/each}}
 </ol>

--- a/templates/buff-effects.hbs
+++ b/templates/buff-effects.hbs
@@ -16,7 +16,7 @@
         <span class="buff-input">+</span>
         <input class="buff-input {{tint effects.taruTotal}}" type="number" value="{{effects.taruTotal}}" disabled />
         <span class="buff-input">-</span>
-        <input class="buff-input" type="number" data-category="tarunda" data-field="amount"
+        <input class="buff-input" type="text" data-category="tarunda" data-field="amount"
             value="{{effects.tarunda.amount}}" />
         <input class="buff-input" type="number" data-category="tarunda" data-field="count"
             value="{{effects.tarunda.count}}" />
@@ -32,7 +32,7 @@
         <span class="buff-input">+</span>
         <input class="buff-input {{tint effects.makaTotal}}" type="number" value="{{effects.makaTotal}}" disabled />
         <span class="buff-input">-</span>
-        <input class="buff-input" type="number" data-category="makunda" data-field="amount"
+        <input class="buff-input" type="text" data-category="makunda" data-field="amount"
             value="{{effects.makunda.amount}}" />
         <input class="buff-input" type="number" data-category="makunda" data-field="count"
             value="{{effects.makunda.count}}" />
@@ -48,7 +48,7 @@
         <span class="buff-input">+</span>
         <input class="buff-input {{tint effects.rakuTotal}}" type="number" value="{{effects.rakuTotal}}" disabled />
         <span class="buff-input">-</span>
-        <input class="buff-input" type="number" data-category="rakunda" data-field="amount"
+        <input class="buff-input" type="text" data-category="rakunda" data-field="amount"
             value="{{effects.rakunda.amount}}" />
         <input class="buff-input" type="number" data-category="rakunda" data-field="count"
             value="{{effects.rakunda.count}}" />
@@ -63,7 +63,7 @@
         <span class="buff-input">+</span>
         <input class="buff-input {{tint effects.sukuTotal}}" type="number" value="{{effects.sukuTotal}}" disabled />
         <span class="buff-input">-</span>
-        <input class="buff-input" type="number" data-category="sukunda" data-field="amount"
+        <input class="buff-input" type="text" data-category="sukunda" data-field="amount"
             value="{{effects.sukunda.amount}}" />
         <input class="buff-input" type="number" data-category="sukunda" data-field="count"
             value="{{effects.sukunda.count}}" />

--- a/templates/buff-effects.hbs
+++ b/templates/buff-effects.hbs
@@ -22,6 +22,7 @@
             value="{{effects.tarunda.count}}" />
     </div>
 
+    {{#ifEq taruOnly false}}
     <div class="flexrow flex-group-center">
         <span class="buff-label flex3">Mag Pow</span>
         <input class="buff-input" type="text" data-category="makakaja" data-field="amount"
@@ -36,6 +37,7 @@
         <input class="buff-input" type="number" data-category="makunda" data-field="count"
             value="{{effects.makunda.count}}" />
     </div>
+    {{/ifEq}}
 
     <div class="flexrow flex-group-center">
         <span class="buff-label flex3">Def</span>
@@ -80,11 +82,13 @@
             value="{{effects.tarukaja.amount}}" />
     </div>
 
+    {{#ifEq taruOnly false}}
     <div class="flexrow flex-group-center">
         <span class="buff-label">Mag Pow</span>
         <input class="buff-input" type="text" data-category="makakaja" data-field="amount"
             value="{{effects.makakaja.amount}}" />
     </div>
+    {{/ifEq}}
 
     <div class="flexrow flex-group-center">
         <span class="buff-label">Def</span>

--- a/templates/buff-effects.hbs
+++ b/templates/buff-effects.hbs
@@ -8,7 +8,7 @@
     </div>
 
     <div class="flexrow flex-group-center">
-        <span class="buff-label flex3">Phy Pow</span>
+        <span class="buff-label flex3">{{#if taruOnly}}Pow{{else}}Phy Pow{{/if}}</span>
         <input class="buff-input" type="text" data-category="tarukaja" data-field="amount"
             value="{{effects.tarukaja.amount}}" />
         <input class="buff-input" type="number" data-category="tarukaja" data-field="count"
@@ -77,7 +77,11 @@
 
     {{#if useTugOfWar}}
     <div class="flexrow flex-group-center">
-        <span class="buff-label">Phy Pow</span>
+        <span class="flex">Min/Max: {{tugMin}} ~ {{tugMax}}</span>
+    </div>
+
+    <div class="flexrow flex-group-center">
+        <span class="buff-label">{{#if taruOnly}}Pow{{else}}Phy Pow{{/if}}</span>
         <input class="buff-input" type="text" data-category="tarukaja" data-field="amount"
             value="{{effects.tarukaja.amount}}" />
     </div>

--- a/templates/buff-effects.hbs
+++ b/templates/buff-effects.hbs
@@ -14,7 +14,7 @@
         <input class="buff-input" type="number" data-category="tarukaja" data-field="count"
             value="{{effects.tarukaja.count}}" />
         <span class="buff-input">+</span>
-        <input class="buff-input" type="number" value="{{effects.taruTotal}}" disabled />
+        <input class="buff-input {{tint effects.taruTotal}}" type="number" value="{{effects.taruTotal}}" disabled />
         <span class="buff-input">-</span>
         <input class="buff-input" type="number" data-category="tarunda" data-field="amount"
             value="{{effects.tarunda.amount}}" />
@@ -30,7 +30,7 @@
         <input class="buff-input" type="number" data-category="makakaja" data-field="count"
             value="{{effects.makakaja.count}}" />
         <span class="buff-input">+</span>
-        <input class="buff-input" type="number" value="{{effects.makaTotal}}" disabled />
+        <input class="buff-input {{tint effects.makaTotal}}" type="number" value="{{effects.makaTotal}}" disabled />
         <span class="buff-input">-</span>
         <input class="buff-input" type="number" data-category="makunda" data-field="amount"
             value="{{effects.makunda.amount}}" />
@@ -46,7 +46,7 @@
         <input class="buff-input" type="number" data-category="rakukaja" data-field="count"
             value="{{effects.rakukaja.count}}" />
         <span class="buff-input">+</span>
-        <input class="buff-input" type="number" value="{{effects.rakuTotal}}" disabled />
+        <input class="buff-input {{tint effects.rakuTotal}}" type="number" value="{{effects.rakuTotal}}" disabled />
         <span class="buff-input">-</span>
         <input class="buff-input" type="number" data-category="rakunda" data-field="amount"
             value="{{effects.rakunda.amount}}" />
@@ -61,7 +61,7 @@
         <input class="buff-input" type="number" data-category="sukukaja" data-field="count"
             value="{{effects.sukukaja.count}}" />
         <span class="buff-input">+</span>
-        <input class="buff-input" type="number" value="{{effects.sukuTotal}}" disabled />
+        <input class="buff-input {{tint effects.sukuTotal}}" type="number" value="{{effects.sukuTotal}}" disabled />
         <span class="buff-input">-</span>
         <input class="buff-input" type="number" data-category="sukunda" data-field="amount"
             value="{{effects.sukunda.amount}}" />
@@ -82,28 +82,28 @@
 
     <div class="flexrow flex-group-center">
         <span class="buff-label">{{#if taruOnly}}Pow{{else}}Phy Pow{{/if}}</span>
-        <input class="buff-input" type="text" data-category="tarukaja" data-field="amount"
-            value="{{effects.tarukaja.amount}}" />
+        <input class="buff-input {{tint effects.tarukaja.amount}}" type="text" data-category="tarukaja"
+            data-field="amount" value="{{effects.tarukaja.amount}}" />
     </div>
 
     {{#ifEq taruOnly false}}
     <div class="flexrow flex-group-center">
         <span class="buff-label">Mag Pow</span>
-        <input class="buff-input" type="text" data-category="makakaja" data-field="amount"
-            value="{{effects.makakaja.amount}}" />
+        <input class="buff-input {{tint effects.makakaja.amount}}" type="text" data-category="makakaja"
+            data-field="amount" value="{{effects.makakaja.amount}}" />
     </div>
     {{/ifEq}}
 
     <div class="flexrow flex-group-center">
         <span class="buff-label">Def</span>
-        <input class="buff-input" type="text" data-category="rakukaja" data-field="amount"
-            value="{{effects.rakukaja.amount}}" />
+        <input class="buff-input {{tint effects.rakukaja.amount}}" type="text" data-category="rakukaja"
+            data-field="amount" value="{{effects.rakukaja.amount}}" />
     </div>
 
     <div class="flexrow flex-group-center">
         <span class="buff-label">Acc</span>
-        <input class="buff-input" type="text" data-category="sukukaja" data-field="amount"
-            value="{{effects.sukukaja.amount}}" />
+        <input class="buff-input {{tint effects.sukukaja.amount}}" type="text" data-category="sukukaja"
+            data-field="amount" value="{{effects.sukukaja.amount}}" />
     </div>
     <hr>
     <div class="flexrow flex-group-center">

--- a/templates/item/item-feature-sheet.hbs
+++ b/templates/item/item-feature-sheet.hbs
@@ -234,11 +234,11 @@
           <label for="system.appliesBadStatus" class="resource-label">Inflicted Status</label>
           {{#if (showTC)}}
           <select name="system.appliesBadStatus">
-            {{selectOptions @root.config.badStatusList_TC selected=system.appliesBadStatus localize=true}}
+            {{selectOptions @root.config.badStatusChoices_TC selected=system.appliesBadStatus localize=true}}
           </select>
           {{else}}
           <select name="system.appliesBadStatus">
-            {{selectOptions @root.config.badStatusList selected=system.appliesBadStatus localize=true}}
+            {{selectOptions @root.config.badStatusChoices selected=system.appliesBadStatus localize=true}}
           </select>
           {{/if}}
         </div>
@@ -260,14 +260,18 @@
         </div>
       </div>
 
-      {{#ifEq system.appliesBadStatus hpCut}}
+      {{#ifEq system.appliesBadStatus "hpCut"}}
       <div class="flexcol">
-        <label for="system.hpCut" class="resource-label" title="Reduce a target's current HP by this percentage">HP
-          Cut</label>
-        <input type="text" name="system.hpCut" value="{{system.hpCut}}" data-dtype="Number" />
+        <label for="system.hpCut" class="resource-label" title="Reduce a target's current HP to this percentage">HP
+          Cut (Reduce a target's current HP to this percentage of itself.)</label>
+        <div class="flexrow">
+          <input type="range" name="system.hpCut" min="0.01" max="1" step="0.01" value="{{system.hpCut}}">
+          <input type="number" disabled value="{{system.hpCut}}">
+        </div>
       </div>
       {{/ifEq}}
-      {{#ifEq system.appliesBadStatus hpSet}}
+
+      {{#ifEq system.appliesBadStatus "hpSet"}}
       <div class="flexcol">
         <label for="system.hpSet" class="resource-label"
           title="Set a target's HP to this value. Blank for no effect; Use -1 to set to Full HP">HP

--- a/templates/item/item-feature-sheet.hbs
+++ b/templates/item/item-feature-sheet.hbs
@@ -219,19 +219,6 @@
             title="The % of MP restored from the effective damage dealt to a target">Mana drain</label>
           <input type="text" name="system.manaDrain" value="{{system.manaDrain}}" data-dtype="Number" />
         </div>
-
-        <div class="flexcol">
-          <label for="system.hpCut" class="resource-label" title="Reduce a target's current HP by this percentage">HP
-            Cut</label>
-          <input type="text" name="system.hpCut" value="{{system.hpCut}}" data-dtype="Number" />
-        </div>
-
-        <div class="flexcol">
-          <label for="system.hpSet" class="resource-label"
-            title="Set a target's HP to this value. Blank for no effect; Use -1 to set to Full HP">HP
-            Set</label>
-          <input type="text" name="system.hpSet" value="{{system.hpSet}}" data-dtype="Number" />
-        </div>
       </div>
 
       <br><br>
@@ -272,6 +259,22 @@
           <button class="remove-effect-link">Click to remove.</button>
         </div>
       </div>
+
+      {{#ifEq system.appliesBadStatus hpCut}}
+      <div class="flexcol">
+        <label for="system.hpCut" class="resource-label" title="Reduce a target's current HP by this percentage">HP
+          Cut</label>
+        <input type="text" name="system.hpCut" value="{{system.hpCut}}" data-dtype="Number" />
+      </div>
+      {{/ifEq}}
+      {{#ifEq system.appliesBadStatus hpSet}}
+      <div class="flexcol">
+        <label for="system.hpSet" class="resource-label"
+          title="Set a target's HP to this value. Blank for no effect; Use -1 to set to Full HP">HP
+          Set</label>
+        <input type="text" name="system.hpSet" value="{{system.hpSet}}" data-dtype="Number" />
+      </div>
+      {{/ifEq}}
 
       <br><br>
 


### PR DESCRIPTION
## v0.884
- Readded the global-system-setting to have Magic Power be affected by Taru- effects
  - When TRUE, the "Magic Power" fields on the buff widget are hidden
- Fixed a buff-widget bug that was causing unexpected results when using Dekaja with "Tug of war" enabled
- The buff widget's total field turns Red/Green based on if the total is positive or negative
- You can now type a + or - and a numerical value into the buff widget fields to accumulate a value
  - for example, if the current value is 4, and you write "+6," the new value will be "10" and the count field will also handily increment by 1
  - This QoL is for those who use the widget directly, rather than buff-configured skills
- Added some stub data paths to the template for Link/Sub actor features (summoners, transformation, etc.)
  - when its implemented, ideally a Sub actor's costs will be sent to the Link for payment/processing
- Tested out a condensed affinity icon view (like strange journey or smt v) but disabled due to heavily WIP
- HP CUT and HP SET are now choices in the Bad Status configuration drop down list.
- fixed a bug related to paying for skill costs
- added new `system.(hp|mp|fate).maxMod` data paths for Active Effects to target.
  - They even support writing `@variables` for complex formulas such as `@stats.st.value * 2` (add double Strength)
- NPC Demon sheet now use the new action styling w/ expandable description-effect text
- Various formatting changes (more padding for readability, uses-pips no longer grow vertically, and more)