### PR TITLE
v 0.890

### DIFF
--- a/css/smt-200x.css
+++ b/css/smt-200x.css
@@ -669,3 +669,23 @@
 .bar-between {
   margin-left: 6px;
 }
+
+
+/* From Kayne's status layout */
+.quick-status-list {
+  margin: 0;
+  display: flex;
+  flex-direction: row;
+  grid-column: span 2;
+  overflow-y: overlay;
+}
+
+.quick-status-list-npc {
+  grid-column: span 3;
+}
+
+.quick-status {
+  margin: 0;
+  height: 30px;
+  max-width: 30px;
+}

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -562,7 +562,7 @@ export class SMTXActor extends Actor {
 
 
 
-  async applyDamage(amount, mult, affinity = "almighty", ignoreDefense = false, halfDefense = false, crit = false, affectsHP = true, affectsMP = false, lifedrain = 0, manadrain = 0, affectsMPmultiplier = 1.0, attackerTokenID = null, attackerActorID = null) {
+  async applyDamage(amount, mult, affinity = "almighty", ignoreDefense = false, halfDefense = false, crit = false, affectsHP = true, affectsMP = false, lifedrain = 0, manadrain = 0, affectsMPHalf = false, attackerTokenID = null, attackerActorID = null) {
     // 1. Determine base defense based on the incoming affinity.
     let defense = this.system.magdef;
     if (affinity === "strike" || affinity === "gun") {
@@ -738,7 +738,7 @@ export class SMTXActor extends Actor {
     const currentMP = this.system.mp.value;
 
     const newHP = Math.max(currentHP - finalAmount, 0);
-    const newMP = Math.max(currentMP - (finalAmount * affectsMPmultiplier), 0)
+    const newMP = Math.max(currentMP - (finalAmount * (affectsMPHalf ? 0.5 : 1)), 0)
 
     if (affectsMP)
       this.update({ "system.mp.value": newMP });
@@ -796,7 +796,7 @@ export class SMTXActor extends Actor {
 
 
 
-  applyHeal(amount, affectsHP = true, affectsMP = false, affectsMPmultiplier = 1.0) {
+  applyHeal(amount, affectsHP = true, affectsMP = false, affectsMPHalf = false) {
     const currentHP = this.system.hp.value;
     const currentMP = this.system.mp.value
 
@@ -804,13 +804,16 @@ export class SMTXActor extends Actor {
     <div class="flexrow damage-line"><div>`
 
     if (affectsHP) {
-      let hpAmount = Math.abs(amount);
-      this.update({ "system.hp.value": currentHP + Math.abs(amount) });
+      let hpAmount = Math.floor(Math.abs(amount));
+      this.update({ "system.hp.value": currentHP + hpAmount });
       chatContent += `<div style="font-size: var(--font-size-16);">Received <strong>${hpAmount}</strong> HP.</div>`
     }
 
     if (affectsMP) {
-      let mpAmount = Math.abs(amount * affectsMPmultiplier);
+      let mpAmount = Math.floor(Math.abs(amount * (affectsMPHalf ? 0.5 : 1)));
+      console.log(affectsMPHalf);
+      console.log(amount);
+      console.log(mpAmount);
       this.update({ "system.mp.value": currentMP + mpAmount });
       chatContent += `<div style="font-size: var(--font-size-16);">Received <strong>${mpAmount}</strong> MP.</div>`
     }

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -19,6 +19,25 @@ export class SMTXActor extends Actor {
     if (this.type === 'character') {
       this._calculateCharacterLevel(systemData);
     }
+
+    console.log(this);
+
+    for (let effect of this.appliedEffects) {
+      for (let change of effect.changes) {
+        // Only if it's a string formula
+        if (typeof change.value === "string" && /[+\-d@]/.test(change.value)) {
+          // 4) Roll it synchronously
+          try {
+            const total = this.parseFormula(change.value, systemData);
+            // 5) Overwrite the change so downstream sees a number
+            change.value = total;
+          }
+          catch (err) {
+            console.error("Error parsing effect formula", change.value, err);
+          }
+        }
+      }
+    }
   }
 
 
@@ -422,6 +441,8 @@ export class SMTXActor extends Actor {
 
   _calculateCombatStats(systemData) {
     // Compute final stats with buffs
+    console.log(systemData.phydef);
+    console.log(this);
     const phyDefFormula = this.parseFormula(systemData.human ? game.settings.get("smt-200x", "phyDefHuman") : game.settings.get("smt-200x", "phyDefDemon"), systemData);
     const magDefFormula = this.parseFormula(systemData.human ? game.settings.get("smt-200x", "magDefHuman") : game.settings.get("smt-200x", "magDefDemon"), systemData);
     const initFormula = this.parseFormula(game.settings.get("smt-200x", "initFormula"), systemData);

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -20,13 +20,11 @@ export class SMTXActor extends Actor {
       this._calculateCharacterLevel(systemData);
     }
 
-    console.log(this);
 
+    // Pre parse active effects
     for (let effect of this.appliedEffects) {
       for (let change of effect.changes) {
-        // Only if it's a string formula
         if (typeof change.value === "string" && /[+\-d@]/.test(change.value)) {
-          // 4) Roll it synchronously
           try {
             const total = this.parseFormula(change.value, systemData);
             // 5) Overwrite the change so downstream sees a number
@@ -441,8 +439,6 @@ export class SMTXActor extends Actor {
 
   _calculateCombatStats(systemData) {
     // Compute final stats with buffs
-    console.log(systemData.phydef);
-    console.log(this);
     const phyDefFormula = this.parseFormula(systemData.human ? game.settings.get("smt-200x", "phyDefHuman") : game.settings.get("smt-200x", "phyDefDemon"), systemData);
     const magDefFormula = this.parseFormula(systemData.human ? game.settings.get("smt-200x", "magDefHuman") : game.settings.get("smt-200x", "magDefDemon"), systemData);
     const initFormula = this.parseFormula(game.settings.get("smt-200x", "initFormula"), systemData);

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -811,9 +811,6 @@ export class SMTXActor extends Actor {
 
     if (affectsMP) {
       let mpAmount = Math.floor(Math.abs(amount * (affectsMPHalf ? 0.5 : 1)));
-      console.log(affectsMPHalf);
-      console.log(amount);
-      console.log(mpAmount);
       this.update({ "system.mp.value": currentMP + mpAmount });
       chatContent += `<div style="font-size: var(--font-size-16);">Received <strong>${mpAmount}</strong> MP.</div>`
     }

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -751,6 +751,9 @@ export class SMTXActor extends Actor {
     if (damageApplied < finalAmount)
       extraNote = ` (${finalAmount - damageApplied} Overkill)`;
 
+    if (affectsMP)
+      extraNote += `<br> and ${(finalAmount * affectsMPmultiplier)} MP damage`
+
     if (lifedrain > 0)
       extraNote += `<br>${Math.floor(damageApplied * lifedrain)} Life Drained`;
     if (manadrain > 0)
@@ -760,7 +763,7 @@ export class SMTXActor extends Actor {
     let chatContent = `
     <div class="flexrow damage-line">
       <span class="damage-text">
-        Received <strong>${damageApplied}</strong> ${game.i18n.localize("SMT_X.Affinity." + affinity)} damage${extraNote}
+        Received <strong>${damageApplied}</strong> ${game.i18n.localize("SMT_X.Affinity." + affinity)} HP damage${extraNote}
         ${fateUsed > 0 ? `<br><em>(Spent ${fateUsed} Fate Point${fateUsed > 1 ? 's' : ''}.)</em>` : ''}
         ${defenseBonus !== 0 ? `<br><em>Defense Bonus: ${defenseBonus}</em>` : ''}
       </span>
@@ -793,18 +796,27 @@ export class SMTXActor extends Actor {
 
 
 
-  applyHeal(amount, affectsHP = true, affectsMP = false) {
+  applyHeal(amount, affectsHP = true, affectsMP = false, affectsMPmultiplier = 1.0) {
     const currentHP = this.system.hp.value;
     const currentMP = this.system.mp.value
 
-    if (affectsMP)
-      this.update({ "system.mp.value": currentMP + Math.abs(amount) });
-    if (affectsHP)
-      this.update({ "system.hp.value": currentHP + Math.abs(amount) });
-
     let chatContent = `
-    <div class="flexrow damage-line">
-      <span style="font-size: var(--font-size-16);">Received <strong>${amount}</strong> healing.</span>
+    <div class="flexrow damage-line"><div>`
+
+    if (affectsHP) {
+      let hpAmount = Math.abs(amount);
+      this.update({ "system.hp.value": currentHP + Math.abs(amount) });
+      chatContent += `<div style="font-size: var(--font-size-16);">Received <strong>${hpAmount}</strong> HP.</div>`
+    }
+
+    if (affectsMP) {
+      let mpAmount = Math.abs(amount * affectsMPmultiplier);
+      this.update({ "system.mp.value": currentMP + mpAmount });
+      chatContent += `<div style="font-size: var(--font-size-16);">Received <strong>${mpAmount}</strong> MP.</div>`
+    }
+
+    chatContent += `
+      </div>
       <button class="flex0 undo-damage height: 32px; width: 32px;" 
               data-actor-id="${this.id}" 
               data-token-id="${this.token ? this.token.id : ''}" 

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -26,7 +26,7 @@ export class SMTXActor extends Actor {
       for (let change of effect.changes) {
         if (typeof change.value === "string" && /[+\-d@]/.test(change.value)) {
           try {
-            const total = this.parseFormula(change.value, systemData);
+            const total = this.parseFormula(change.value, effect.parent.getRollData());
             // 5) Overwrite the change so downstream sees a number
             change.value = total;
           }

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -898,8 +898,10 @@ export class SMTXActor extends Actor {
 
   payCost(itemID) {
     const actorData = this.system;
-    const rollData = this.getRollData();
+    //const rollData = this.getRollData();
     const item = this.items.get(itemID);
+    const rollData = item.getRollData();
+    rollData.targets = game.user.targets.size;
 
     // Retrieve current resource values
     const currentHP = actorData.hp.value;

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -100,6 +100,10 @@ export class SMTXActor extends Actor {
       systemData.stats[key].tn = 0;
     }
 
+    systemData.hp.max = 0;
+    systemData.mp.max = 0;
+    systemData.fate.max = 0;
+    systemData.magdef = 0;
     systemData.phydef = 0;
     systemData.magdef = 0;
     systemData.meleePower = 0;
@@ -475,9 +479,9 @@ export class SMTXActor extends Actor {
     const mpMod = this.parseFormula(systemData.mp.maxMod != undefined ? systemData.mp.maxMod : "0", systemData);
     const fateMod = this.parseFormula(systemData.fate.maxMod != undefined ? systemData.fate.maxMod : "0", systemData);
 
-    systemData.hp.max = ((hpFormula) * systemData.hp.mult) + (hpMod);
-    systemData.mp.max = ((mpFormula) * systemData.mp.mult) + (mpMod);
-    systemData.fate.max = (fateFormula) + (fateMod);
+    systemData.hp.max += ((hpFormula) * systemData.hp.mult) + (hpMod);
+    systemData.mp.max += ((mpFormula) * systemData.mp.mult) + (mpMod);
+    systemData.fate.max += (fateFormula) + (fateMod);
 
     if (systemData.isBoss) {
       systemData.hp.max *= 5;

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -862,6 +862,7 @@ export class SMTXItem extends Item {
           data-ignore-defense="${overrides.ignoreDefense}" 
           data-half-defense="${overrides.halfDefense}" 
           data-pierce="${overrides.pierce}" 
+          data-affects-hp='${systemData.affectsHP}' 
           data-affects-mp='${systemData.affectsMP}' 
           data-regular-damage="${finalBaseDmg}" 
           data-critical-damage="${critDamage}" 
@@ -1142,11 +1143,13 @@ export class SMTXItem extends Item {
   <div class="flexrow"><span class="flex3"><strong>Inc. Dmg:</strong> ${result.finalDamage}</span>
     <button class="apply-damage-btn smtx-roll-button" title="Apply Damage" 
       data-token-id="${result.tokenId}"
+      data-item-id="${this.id}"
       data-effective-damage="${result.effectiveDamage}"
       data-affinity="${systemData.affinity}"
       data-ignore-defense="${systemData.ingoreDefense}"
       data-half-defense="${systemData.halfDefense}"
       data-critical="${baseEffect === 2}"
+      data-affects-hp='${systemData.affectsHP}' 
       data-affects-mp="${systemData.affectsMP}"
       data-lifedrain="${systemData.lifeDrain}"
       data-manadrain="${systemData.manaDrain}"
@@ -1550,6 +1553,7 @@ Hooks.on('renderChatMessage', (message, html, data) => {
     const ignoreDefense = button.data("ignore-defense");
     const halfDefense = button.data("half-defense");
     const critical = button.data("critical") === "true" || button.data("critical") === true;
+    const affectsHP = button.data("affects-hp");
     const affectsMP = button.data("affects-mp");
     const lifedrain = button.data("lifedrain");
     const manadrain = button.data("manadrain");
@@ -1563,6 +1567,7 @@ Hooks.on('renderChatMessage', (message, html, data) => {
       ignoreDefense,
       halfDefense,
       critical,
+      affectsHP,
       affectsMP,
       lifedrain,
       manadrain
@@ -1716,6 +1721,7 @@ Hooks.on('renderChatMessage', (message, html, data) => {
   const ignoreDefense = powerRollCard.data('ignore-defense');
   const halfDefense = powerRollCard.data('half-defense');
   const pierce = powerRollCard.data('pierce');
+  const affectsHP = powerRollCard.data('affects-hp');
   const affectsMP = powerRollCard.data('affects-mp');
 
   // Define the function to apply damage
@@ -1730,9 +1736,9 @@ Hooks.on('renderChatMessage', (message, html, data) => {
       const actor = token.actor;
       if (!actor) return;
       if (heals)
-        actor.applyHeal(amount, affectsMP);
+        actor.applyHeal(amount, affectsHP, affectsMP);
       else
-        actor.applyDamage(amount, mult, affinity, ignoreDefense, halfDefense, crit, pierce, affectsMP);
+        actor.applyDamage(amount, mult, affinity, ignoreDefense, halfDefense, crit, pierce, affectsHP, affectsMP);
     });
   };
 

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -864,6 +864,7 @@ export class SMTXItem extends Item {
           data-pierce="${overrides.pierce}" 
           data-affects-hp='${systemData.affectsHP}' 
           data-affects-mp='${systemData.affectsMP}' 
+          data-affects-mp-half="${systemData.affectsMPHalf}"
           data-regular-damage="${finalBaseDmg}" 
           data-critical-damage="${critDamage}" 
           data-buffs='${JSON.stringify(buffArray)}' 
@@ -1153,6 +1154,7 @@ export class SMTXItem extends Item {
       data-affects-mp="${systemData.affectsMP}"
       data-lifedrain="${systemData.lifeDrain}"
       data-manadrain="${systemData.manaDrain}"
+      data-affects-mp-half="${systemData.affectsMPHalf}"
     >DMG</button>
     </div>` : ``}
     ${(systemData.appliesBadStatus != "NONE" && result.rawBSchance > 0)
@@ -1557,6 +1559,7 @@ Hooks.on('renderChatMessage', (message, html, data) => {
     const affectsMP = button.data("affects-mp");
     const lifedrain = button.data("lifedrain");
     const manadrain = button.data("manadrain");
+    const affectsMPHalf = button.data("affects-mp-half");
 
     const token = canvas.tokens.get(tokenId);
     if (!token || !token.actor) return;
@@ -1570,7 +1573,8 @@ Hooks.on('renderChatMessage', (message, html, data) => {
       affectsHP,
       affectsMP,
       lifedrain,
-      manadrain
+      manadrain,
+      affectsMPHalf
     );
     // Disable the button after applying damage
     //button.prop("disabled", true).text("Damage Applied");
@@ -1723,6 +1727,7 @@ Hooks.on('renderChatMessage', (message, html, data) => {
   const pierce = powerRollCard.data('pierce');
   const affectsHP = powerRollCard.data('affects-hp');
   const affectsMP = powerRollCard.data('affects-mp');
+  const affectsMPHalf = powerRollCard.data('affects-mp-half');
 
   // Define the function to apply damage
   const applyDamage = function (amount, mult = 1, crit = false, heals = false) {
@@ -1736,9 +1741,9 @@ Hooks.on('renderChatMessage', (message, html, data) => {
       const actor = token.actor;
       if (!actor) return;
       if (heals)
-        actor.applyHeal(amount, affectsHP, affectsMP);
+        actor.applyHeal(amount, affectsHP, affectsMP, affectsMPHalf);
       else
-        actor.applyDamage(amount, mult, affinity, ignoreDefense, halfDefense, crit, pierce, affectsHP, affectsMP);
+        actor.applyDamage(amount, mult, affinity, ignoreDefense, halfDefense, crit, pierce, affectsHP, affectsMP, affectsMPHalf);
     });
   };
 

--- a/system.json
+++ b/system.json
@@ -20,7 +20,7 @@
       "thumbnail": "systems/smt-200x/assets/anvil-impact.png"
     }
   ],
-  "version": "0.887",
+  "version": "0.890",
   "compatibility": {
     "minimum": 12,
     "verified": "12.331"
@@ -57,7 +57,7 @@
   "packFolders": [],
   "socket": true,
   "manifest": "https://github.com/Alondaar/smt-200x/raw/main/system.json",
-  "download": "https://github.com/Alondaar/smt-200x/archive/refs/tags/release-033.zip",
+  "download": "https://github.com/Alondaar/smt-200x/archive/refs/tags/release-034.zip",
   "background": "systems/smt-200x/assets/anvil-impact.png",
   "gridDistance": 2,
   "gridUnits": "m",

--- a/template.json
+++ b/template.json
@@ -463,6 +463,7 @@
       "badStatusChance": "0",
       "attackType": "none",
       "disableMultiaction": false,
+      "rank": 0,
       "buffs": {
         "sukukaja": false,
         "sukunda": false,

--- a/template.json
+++ b/template.json
@@ -403,6 +403,8 @@
       "hasType": false,
       "lifeDrain": 0,
       "manaDrain": 0,
+      "affectsHPmultiplier": 1.0,
+      "affectsMPmultiplier": 1.0,
       "hpCut": 0,
       "hpSet": "",
       "buffs": {

--- a/template.json
+++ b/template.json
@@ -289,7 +289,8 @@
       "item": {
         "gp": 1,
         "buy": "0",
-        "sell": "0"
+        "sell": "0",
+        "quantity": 1
       },
       "equipment": {
         "vtReq": 0,
@@ -330,6 +331,62 @@
           "HAPPY": "none",
           "BS": "none"
         }
+      },
+      "skill": {
+        "cost": "-",
+        "target": "1",
+        "wep": "x",
+        "wepIgnoreTN": false,
+        "wepIgnorePower": false,
+        "baseTN": "auto",
+        "modTN": "0",
+        "basePower": "none",
+        "modPower": "0",
+        "basePowerDice": "match",
+        "modPowerDice": "0",
+        "explodeDice": true,
+        "tn": "",
+        "power": "",
+        "powerDice": "",
+        "affinity": "strike",
+        "ingoreDefense": false,
+        "halfDefense": false,
+        "pierce": false,
+        "critMult": 2,
+        "primaryMult": 1,
+        "critRange": "1/10",
+        "flatCritChance": 0,
+        "flatCritDamage": 0,
+        "powerBoost": 1,
+        "hpCost": "0",
+        "mpCost": "0",
+        "fateCost": "0",
+        "ammoCost": "0",
+        "hideCritDamage": false,
+        "affectsHP": true,
+        "affectsMP": false,
+        "actionPattern": "-",
+        "appliesBadStatus": "NONE",
+        "badStatusChance": "0",
+        "attackType": "none",
+        "disableMultiaction": false,
+        "rank": 0,
+        "buffs": {
+          "sukukaja": false,
+          "sukunda": false,
+          "tarukaja": false,
+          "tarunda": false,
+          "rakukaja": false,
+          "rakunda": false,
+          "makakaja": false,
+          "makunda": false
+        },
+        "subBuffRoll": "",
+        "uses": {
+          "value": 0,
+          "max": 0
+        },
+        "inflictedEffect": ""
       }
     },
     "weapon": {
@@ -370,118 +427,15 @@
     "consumable": {
       "templates": [
         "base",
-        "item"
-      ],
-      "cost": "-",
-      "target": "1",
-      "wep": "x",
-      "wepIgnoreTN": false,
-      "wepIgnorePower": false,
-      "tn": "0",
-      "power": "0",
-      "powerDice": "1d10x",
-      "affinity": "strike",
-      "ingoreDefense": false,
-      "pierce": false,
-      "critMult": 2,
-      "primaryMult": 1,
-      "critRange": "1/10",
-      "flatCritChance": 0,
-      "flatCritDamage": 0,
-      "powerBoost": 1,
-      "hpCost": "0",
-      "mpCost": "0",
-      "fateCost": "0",
-      "hideCritDamage": true,
-      "affectsHP": true,
-      "affectsMP": false,
-      "actionPattern": "-",
-      "reloads": false,
-      "hasPower": false,
-      "hasAffinity": false,
-      "hasTarget": false,
-      "hasType": false,
-      "lifeDrain": 0,
-      "manaDrain": 0,
-      "affectsHPmultiplier": 1.0,
-      "affectsMPmultiplier": 1.0,
-      "hpCut": 0,
-      "hpSet": "",
-      "buffs": {
-        "sukukaja": false,
-        "sukunda": false,
-        "tarukaja": false,
-        "tarunda": false,
-        "rakukaja": false,
-        "rakunda": false,
-        "makakaja": false,
-        "makunda": false
-      },
-      "subBuffRoll": "",
-      "uses": {
-        "value": 0,
-        "max": 0
-      },
-      "quantity": 0
+        "item",
+        "skill"
+      ]
     },
     "feature": {
       "templates": [
-        "base"
-      ],
-      "cost": "-",
-      "target": "1",
-      "wep": "x",
-      "wepIgnoreTN": false,
-      "wepIgnorePower": false,
-      "baseTN": "auto",
-      "modTN": "0",
-      "basePower": "none",
-      "modPower": "0",
-      "basePowerDice": "match",
-      "modPowerDice": "0",
-      "explodeDice": true,
-      "tn": "",
-      "power": "",
-      "powerDice": "",
-      "affinity": "strike",
-      "ingoreDefense": false,
-      "halfDefense": false,
-      "pierce": false,
-      "critMult": 2,
-      "primaryMult": 1,
-      "critRange": "1/10",
-      "flatCritChance": 0,
-      "flatCritDamage": 0,
-      "powerBoost": 1,
-      "hpCost": "0",
-      "mpCost": "0",
-      "fateCost": "0",
-      "ammoCost": "0",
-      "hideCritDamage": false,
-      "affectsHP": true,
-      "affectsMP": false,
-      "actionPattern": "-",
-      "appliesBadStatus": "NONE",
-      "badStatusChance": "0",
-      "attackType": "none",
-      "disableMultiaction": false,
-      "rank": 0,
-      "buffs": {
-        "sukukaja": false,
-        "sukunda": false,
-        "tarukaja": false,
-        "tarunda": false,
-        "rakukaja": false,
-        "rakunda": false,
-        "makakaja": false,
-        "makunda": false
-      },
-      "subBuffRoll": "",
-      "uses": {
-        "value": 0,
-        "max": 0
-      },
-      "inflictedEffect": ""
+        "base",
+        "skill"
+      ]
     },
     "passive": {
       "templates": [

--- a/template.json
+++ b/template.json
@@ -365,7 +365,7 @@
         "hideCritDamage": false,
         "affectsHP": true,
         "affectsMP": false,
-        "affectsMPmultiplier": 1.0,
+        "affectsMPHalf": false,
         "actionPattern": "-",
         "appliesBadStatus": "NONE",
         "badStatusChance": "0",

--- a/template.json
+++ b/template.json
@@ -365,6 +365,7 @@
         "hideCritDamage": false,
         "affectsHP": true,
         "affectsMP": false,
+        "affectsMPmultiplier": 1.0,
         "actionPattern": "-",
         "appliesBadStatus": "NONE",
         "badStatusChance": "0",
@@ -429,7 +430,8 @@
         "base",
         "item",
         "skill"
-      ]
+      ],
+      "reloads": false
     },
     "feature": {
       "templates": [

--- a/template.json
+++ b/template.json
@@ -207,6 +207,8 @@
         "race": "",
         "alignment": "",
         "macca": 0,
+        "magnetite": 0,
+        "forma": 0,
         "gems": {
           "diamond": 0,
           "pearl": 0,

--- a/templates/actor/actor-character-sheet.hbs
+++ b/templates/actor/actor-character-sheet.hbs
@@ -228,33 +228,32 @@
             <input type="text" name="system.quickModTN" value="{{system.quickModTN}}%" data-dtype="Number" disabled />
             <i class="fa-solid clickable fa-plus increase-quickModTN" style="margin: auto;"></i>
           </div>
-          <div class="align-center clickable custom-power-roll">Custom Power Roll <i class="fa-solid fa-person-burst"
+
+          <div class="align-center clickable custom-power-roll">Power Roll <i class="fa-solid fa-person-burst"
               style="margin: auto;"></i>
           </div>
-        </div>
-      </section>
 
-      <section class="main">
-        <ol class="items-list effects-list">
-          <ol class="item-list">
-            <div class="grid grid-5col" style="margin: 0;">
+          <div class="grid-span-2">
+            <ol class="item-list quick-status-list">
               {{#each effects.temporary.effects as |effect|}}
-              <li class="item effect flexrow item-prop" data-effect-id="{{effect.id}}"
-                data-parent-id="{{effect.parent.id}}">
-                <div class="item-name effect-name flexrow">
-                  <img class="item-image" src="{{effect.img}}" />
-                  <h4>{{effect.name}}</h4>
-                </div>
-                <div class="item-controls effect-controls flexrow">
-                  <a class="effect-control" data-action="toggle" title="{{localize 'SMT_X.Effect.Toggle'}}">
-                    <i class="fas {{#if effect.disabled}}fa-check{{else}}fa-times{{/if}}"></i>
-                  </a>
-                </div>
+              <li class="item effect flexrow" data-effect-id="{{effect.id}}" data-parent-id="{{effect.parent.id}}">
+                <img title="{{effect.name}}" class="item-image quick-status effect-control" {{#ifEq
+                  effect.sourceName "None" }} data-action="delete" {{else}} data-action="toggle" {{/ifEq}}
+                  style="margin-right: 2px;" src="{{effect.icon}}" />
               </li>
               {{/each}}
-            </div>
-          </ol>
-        </ol>
+              <span style="margin-left: 2px; margin-right: 4px; font-weight: bold; font-size: 1.25em;">|</span>
+              {{#each effects.inactive.effects as |effect|}}
+              {{#if effect.isTemporary}}
+              <li class="item effect flexrow" data-effect-id="{{effect.id}}" data-parent-id="{{effect.parent.id}}">
+                <img title="{{effect.name}}" class="item-image quick-status effect-control" data-action="toggle"
+                  style="filter: grayscale(1); margin-right: 2px;" src="{{effect.icon}}" />
+              </li>
+              {{/if}}
+              {{/each}}
+            </ol>
+          </div>
+        </div>
       </section>
 
       <section class="main">

--- a/templates/actor/actor-character-sheet.hbs
+++ b/templates/actor/actor-character-sheet.hbs
@@ -239,7 +239,7 @@
               <li class="item effect flexrow" data-effect-id="{{effect.id}}" data-parent-id="{{effect.parent.id}}">
                 <img title="{{effect.name}}" class="item-image quick-status effect-control" {{#ifEq
                   effect.sourceName "None" }} data-action="delete" {{else}} data-action="toggle" {{/ifEq}}
-                  style="margin-right: 2px;" src="{{effect.icon}}" />
+                  style="margin-right: 2px; cursor: pointer;" src="{{effect.icon}}" />
               </li>
               {{/each}}
               <span style="margin-left: 2px; margin-right: 4px; font-weight: bold; font-size: 1.25em;">|</span>
@@ -247,7 +247,7 @@
               {{#if effect.isTemporary}}
               <li class="item effect flexrow" data-effect-id="{{effect.id}}" data-parent-id="{{effect.parent.id}}">
                 <img title="{{effect.name}}" class="item-image quick-status effect-control" data-action="toggle"
-                  style="filter: grayscale(1); margin-right: 2px;" src="{{effect.icon}}" />
+                  style="filter: grayscale(1); margin-right: 2px; cursor: pointer;" src="{{effect.icon}}" />
               </li>
               {{/if}}
               {{/each}}

--- a/templates/actor/actor-npc-sheet.hbs
+++ b/templates/actor/actor-npc-sheet.hbs
@@ -253,7 +253,7 @@
     {{!-- Owned Features Tab --}}
     <div class="tab features" data-group="primary" data-tab="features">
       <section class="main">
-        <div class="grid grid-4col">
+        <div class="grid grid-4col" style="margin: 0;">
           <div class="flexrow flex-center flex-between align-center">
             <i title="Toggles resetting this field to 0% after rolling a TN check."
               class="fa-solid clickable {{#if system.resetModTN}}fa-arrows-spin{{else}}fa-xmark{{/if}} toggle-resetModTN"
@@ -262,6 +262,31 @@
             <i class="fa-solid clickable fa-minus decrease-quickModTN" style="margin: auto;"></i>
             <input type="text" name="system.quickModTN" value="{{system.quickModTN}}%" data-dtype="Number" disabled />
             <i class="fa-solid clickable fa-plus increase-quickModTN" style="margin: auto;"></i>
+          </div>
+
+          <div class="align-center clickable custom-power-roll">Power Roll <i class="fa-solid fa-person-burst"
+              style="margin: auto;"></i>
+          </div>
+
+          <div class="grid-span-2">
+            <ol class="item-list quick-status-list">
+              {{#each effects.temporary.effects as |effect|}}
+              <li class="item effect flexrow" data-effect-id="{{effect.id}}" data-parent-id="{{effect.parent.id}}">
+                <img title="{{effect.name}}" class="item-image quick-status effect-control" {{#ifEq
+                  effect.sourceName "None" }} data-action="delete" {{else}} data-action="toggle" {{/ifEq}}
+                  style="margin-right: 2px; cursor: pointer;" src="{{effect.icon}}" />
+              </li>
+              {{/each}}
+              <span style="margin-left: 2px; margin-right: 4px; font-weight: bold; font-size: 1.25em;">|</span>
+              {{#each effects.inactive.effects as |effect|}}
+              {{#if effect.isTemporary}}
+              <li class="item effect flexrow" data-effect-id="{{effect.id}}" data-parent-id="{{effect.parent.id}}">
+                <img title="{{effect.name}}" class="item-image quick-status effect-control" data-action="toggle"
+                  style="filter: grayscale(1); margin-right: 2px; cursor: pointer;" src="{{effect.icon}}" />
+              </li>
+              {{/if}}
+              {{/each}}
+            </ol>
           </div>
         </div>
       </section>

--- a/templates/actor/parts/actor-effects.hbs
+++ b/templates/actor/parts/actor-effects.hbs
@@ -2,7 +2,7 @@
   {{#each effects as |section sid|}}
   <li class="items-header flexrow" data-effect-type="{{section.type}}" data-parent-id="{{@root.actor.id}}">
     <div class="item-name effect-name flexrow">{{localize section.label}}</div>
-    <div class="item-controls effect-controls flexrow">
+    <div class="item-controls effect-controls flexrow" style="flex: 0 0 60px;">
       <a class="effect-control" data-action="create" title="{{localize 'DOCUMENT.Create' type=" Effect"}}">
         <i class="fas fa-plus"></i> <!--{{localize "DOCUMENT.New" type="Effect"}}-->
       </a>
@@ -16,7 +16,7 @@
         <img class="item-image" src="{{effect.img}}" />
         <h4>{{effect.name}}</h4>
       </div>
-      <div class="item-controls effect-controls flexrow">
+      <div class="item-controls effect-controls flexrow" style="flex: 0 0 60px;">
         <a class="effect-control" data-action="toggle" title="{{localize 'SMT_X.Effect.Toggle'}}">
           <i class="fas {{#if effect.disabled}}fa-check{{else}}fa-times{{/if}}"></i>
         </a>

--- a/templates/item/item-consumable-sheet.hbs
+++ b/templates/item/item-consumable-sheet.hbs
@@ -32,6 +32,11 @@
         </div>
 
         <div class="flexcol">
+          <label for="system.quantity" class="resource-label">Quantity</label>
+          <input type="text" name="system.quantity" value="{{system.quantity}}" data-dtype="Number" />
+        </div>
+
+        <div class="flexcol">
           <label for="system.target" class="resource-label">Target</label>
           <input type="text" name="system.target" value="{{system.target}}" />
         </div>
@@ -41,11 +46,6 @@
           <select name="system.affinity">
             {{selectOptions @root.config.affinities selected=system.affinity localize=true}}
           </select>
-        </div>
-
-        <div class="flexcol">
-          <label for="system.quantity" class="resource-label">Quantity</label>
-          <input type="text" name="system.quantity" value="{{system.quantity}}" data-dtype="Number" />
         </div>
 
         <div class="flexcol">
@@ -61,16 +61,73 @@
 
       <br><br>
 
-      <h2>ROLL and CHECK DATA</h2>
+      <h2>Target Number Config</h2>
       <div class="flexrow">
         <div class="flexcol">
-          <label for="system.powerDice" class="resource-label">Power Dice</label>
-          <input type="text" name="system.powerDice" value="{{system.powerDice}}" />
+          <label class="resource-label">TN Base</label>
+          <select name="system.baseTN" {{#ifEq system.tn "" }}{{else}}disabled{{/ifEq}}>
+            {{selectOptions @root.config.tns localize=true selected=system.baseTN}}
+          </select>
         </div>
 
         <div class="flexcol flex2">
-          <label for="system.power" class="resource-label">Power</label>
+          <label for="system.modTN" class="resource-label">TN Mod</label>
+          <input type="text" name="system.modTN" value="{{system.modTN}}" />
+        </div>
+
+        <div class="flexcol flex2">
+          <label for="system.tn" class="resource-label">TN Base Override</label>
+          <input type="text" name="system.tn" value="{{system.tn}}" />
+        </div>
+      </div>
+
+      <br>
+      <h2>Power Config</h2>
+      <div class="flexrow">
+        <div class="flexcol">
+          <label class="resource-label">Power Base</label>
+          <select name="system.basePower" {{#ifEq system.power "" }}{{else}}disabled{{/ifEq}}>
+            {{selectOptions @root.config.powers localize=true selected=system.basePower}}
+          </select>
+        </div>
+
+        <div class="flexcol flex2">
+          <label for="system.modPower" class="resource-label">Power Mod</label>
+          <input type="text" name="system.modPower" value="{{system.modPower}}" />
+        </div>
+
+        <div class="flexcol flex2">
+          <label for="system.power" class="resource-label">Power Base Override</label>
           <input type="text" name="system.power" value="{{system.power}}" />
+        </div>
+      </div>
+
+      <br>
+      <h2>Power Dice Config</h2>
+      <div class="flexrow">
+        <div class="flexcol">
+          <label class="resource-label">Dice Base</label>
+          <select name="system.basePowerDice" {{#ifEq system.powerDice "" }}{{else}}disabled{{/ifEq}}>
+            {{selectOptions @root.config.powerDice localize=true selected=system.basePowerDice}}
+          </select>
+        </div>
+
+        <div class="flexcol">
+          <label for="system.modPowerDice" class="resource-label">Extra Dice</label>
+          <input type="number" name="system.modPowerDice" value="{{system.modPowerDice}}" {{#ifEq system.powerDice ""
+            }}{{else}}disabled{{/ifEq}} />
+        </div>
+
+        <div class="flexcol">
+          <label for="system.explodeDice" class="resource-label">Exploding</label>
+          <input type="checkbox" name="system.explodeDice" {{#if system.explodeDice}}checked{{/if}} {{#ifEq
+            system.powerDice "" }}{{else}}disabled{{/ifEq}} />
+        </div>
+
+        <div class="flexcol flex3">
+          <label for="system.powerDice" class="resource-label"
+            title="The dice used for an attack. 1d10x for exploding dice.">Dice Override</label>
+          <input type="text" name="system.powerDice" value="{{system.powerDice}}" />
         </div>
       </div>
 
@@ -84,6 +141,11 @@
         </div>
 
         <div class="flexcol">
+          <label for="system.halfDefense" class="resource-label">Ignores 1/2 Defense</label>
+          <input type="checkbox" name="system.halfDefense" {{#if system.halfDefense}}checked{{/if}} />
+        </div>
+
+        <div class="flexcol">
           <label for="system.pierce" class="resource-label">Pierce (unused)</label>
           <input type="checkbox" name="system.pierce" {{#if system.pierce}}checked{{/if}} />
         </div>
@@ -94,10 +156,99 @@
         </div>
 
         <div class="flexcol">
+          <label for="system.affectsHP" class="resource-label">Affects HP</label>
+          <input type="checkbox" name="system.affectsHP" {{#if system.affectsHP}}checked{{/if}} />
+        </div>
+
+        <div class="flexcol">
           <label for="system.affectsMP" class="resource-label">Affects MP</label>
           <input type="checkbox" name="system.affectsMP" {{#if system.affectsMP}}checked{{/if}} />
         </div>
+
+        <div class="flexcol">
+          <label class="resource-label" title="This affects some niche rules cases and Bad Status interactions.">Attack
+            Type</label>
+          <select class="flex0" name="system.attackType">
+            {{selectOptions @root.config.attackTypes localize=true selected=system.attackType}}
+          </select>
+        </div>
+
+        <div class="flexcol">
+          <label for="system.disableMultiaction" class="resource-label">Disable Multi-action</label>
+          <input type="checkbox" name="system.disableMultiaction" {{#if system.disableMultiaction}}checked{{/if}} />
+        </div>
+
+        <div class="flexcol">
+          <label for="system.lifeDrain" class="resource-label"
+            title="The % of HP restored from the effective damage dealt to a target">Life drain</label>
+          <input type="text" name="system.lifeDrain" value="{{system.lifeDrain}}" data-dtype="Number" />
+        </div>
+
+        <div class="flexcol">
+          <label for="system.manaDrain" class="resource-label"
+            title="The % of MP restored from the effective damage dealt to a target">Mana drain</label>
+          <input type="text" name="system.manaDrain" value="{{system.manaDrain}}" data-dtype="Number" />
+        </div>
       </div>
+
+      <br><br>
+
+      <h2>BAD STATUS CONFIGURATION</h2>
+      <div class="grid grid-4col">
+        <div class="flexcol">
+          <label for="system.badStatusChance" class="resource-label">BS%</label>
+          <input type="number" name="system.badStatusChance" value="{{system.badStatusChance}}" />
+        </div>
+
+        <div class="flexcol">
+          <label for="system.appliesBadStatus" class="resource-label">Inflicted Status</label>
+          {{#if (showTC)}}
+          <select name="system.appliesBadStatus">
+            {{selectOptions @root.config.badStatusChoices_TC selected=system.appliesBadStatus localize=true}}
+          </select>
+          {{else}}
+          <select name="system.appliesBadStatus">
+            {{selectOptions @root.config.badStatusChoices selected=system.appliesBadStatus localize=true}}
+          </select>
+          {{/if}}
+        </div>
+
+        <div class="flexcol">
+          <label>Inflicted Effect</label>
+          <div class="effect-drop-zone" style="border: 2px dashed #888; padding: 10px; text-align: center;">
+            {{#if system.inflictedEffect}}
+            <p>Linked Effect: {{system.inflictedEffect}}</p>
+            {{else}}
+            <p>Drag an effect here</p>
+            {{/if}}
+          </div>
+        </div>
+
+        <div class="flexcol">
+          <label class="resource-label">Remove Link</label>
+          <button class="remove-effect-link">Click to remove.</button>
+        </div>
+      </div>
+
+      {{#ifEq system.appliesBadStatus "hpCut"}}
+      <div class="flexcol">
+        <label for="system.hpCut" class="resource-label" title="Reduce a target's current HP to this percentage">HP
+          Cut (Reduce a target's current HP to this percentage of itself.)</label>
+        <div class="flexrow">
+          <input type="range" name="system.hpCut" min="0.01" max="1" step="0.01" value="{{system.hpCut}}">
+          <input type="number" disabled value="{{system.hpCut}}">
+        </div>
+      </div>
+      {{/ifEq}}
+
+      {{#ifEq system.appliesBadStatus "hpSet"}}
+      <div class="flexcol">
+        <label for="system.hpSet" class="resource-label"
+          title="Set a target's HP to this value. Blank for no effect; Use -1 to set to Full HP">HP
+          Set</label>
+        <input type="text" name="system.hpSet" value="{{system.hpSet}}" data-dtype="Number" />
+      </div>
+      {{/ifEq}}
 
       <br><br>
 

--- a/templates/item/item-consumable-sheet.hbs
+++ b/templates/item/item-consumable-sheet.hbs
@@ -166,6 +166,11 @@
         </div>
 
         <div class="flexcol">
+          <label for="system.affectsMPHalf" class="resource-label">Affects MP Half</label>
+          <input type="checkbox" name="system.affectsMPHalf" {{#if system.affectsMPHalf}}checked{{/if}} />
+        </div>
+
+        <div class="flexcol">
           <label class="resource-label" title="This affects some niche rules cases and Bad Status interactions.">Attack
             Type</label>
           <select class="flex0" name="system.attackType">

--- a/templates/item/item-feature-sheet.hbs
+++ b/templates/item/item-feature-sheet.hbs
@@ -196,6 +196,11 @@
         </div>
 
         <div class="flexcol">
+          <label for="system.affectsMPHalf" class="resource-label">Affects MP Half</label>
+          <input type="checkbox" name="system.affectsMPHalf" {{#if system.affectsMPHalf}}checked{{/if}} />
+        </div>
+
+        <div class="flexcol">
           <label class="resource-label" title="This affects some niche rules cases and Bad Status interactions.">Attack
             Type</label>
           <select class="flex0" name="system.attackType">

--- a/templates/item/parts/item-effects.hbs
+++ b/templates/item/parts/item-effects.hbs
@@ -1,38 +1,38 @@
 <ol class="items-list effects-list">
   {{#each effects as |section sid|}}
-    <li class="items-header flexrow" data-effect-type="{{section.type}}">
-      <h3 class="item-name effect-name flexrow">{{localize section.label}}</h3>
-      <div class="effect-source">{{localize "SMT_X.Effect.Source"}}</div>
-      <div class="effect-source">{{localize "EFFECT.TabDuration"}}</div>
-      <div class="item-controls effect-controls flexrow">
-        <a class="effect-control" data-action="create" title="{{localize 'DOCUMENT.Create' type="Effect"}}">
-          <i class="fas fa-plus"></i> {{localize "DOCUMENT.New" type="Effect"}}
+  <li class="items-header flexrow" data-effect-type="{{section.type}}">
+    <h3 class="item-name effect-name flexrow">{{localize section.label}}</h3>
+    <div class="effect-source">{{localize "SMT_X.Effect.Source"}}</div>
+    <div class="effect-source">{{localize "EFFECT.TabDuration"}}</div>
+    <div class="item-controls effect-controls flexrow" style="flex: 0 0 60px;">
+      <a class="effect-control" data-action="create" title="{{localize 'DOCUMENT.Create' type=" Effect"}}">
+        <i class="fas fa-plus"></i> <!--{{localize "DOCUMENT.New" type="Effect"}}-->
+      </a>
+    </div>
+  </li>
+
+  <ol class="item-list">
+    {{#each section.effects as |effect|}}
+    <li class="item effect flexrow" data-effect-id="{{effect.id}}" data-parent-id="{{effect.parent.id}}">
+      <div class="item-name effect-name flexrow">
+        <img class="item-image" src="{{effect.icon}}" />
+        <h4>{{effect.name}}</h4>
+      </div>
+      <div class="effect-source">{{effect.sourceName}}</div>
+      <div class="effect-duration">{{effect.duration.label}}</div>
+      <div class="item-controls effect-controls flexrow" style="flex: 0 0 60px;">
+        <a class="effect-control" data-action="toggle" title="{{localize 'SMT_X.Effect.Toggle'}}">
+          <i class="fas {{#if effect.disabled}}fa-check{{else}}fa-times{{/if}}"></i>
+        </a>
+        <a class="effect-control" data-action="edit" title="{{localize 'DOCUMENT.Update' type=" Effect"}}">
+          <i class="fas fa-edit"></i>
+        </a>
+        <a class="effect-control" data-action="delete" title="{{localize 'DOCUMENT.Delete' type=" Effect"}}">
+          <i class="fas fa-trash"></i>
         </a>
       </div>
     </li>
-
-    <ol class="item-list">
-    {{#each section.effects as |effect|}}
-      <li class="item effect flexrow" data-effect-id="{{effect.id}}" data-parent-id="{{effect.parent.id}}">
-        <div class="item-name effect-name flexrow">
-          <img class="item-image" src="{{effect.icon}}"/>
-          <h4>{{effect.name}}</h4>
-        </div>
-        <div class="effect-source">{{effect.sourceName}}</div>
-        <div class="effect-duration">{{effect.duration.label}}</div>
-        <div class="item-controls effect-controls flexrow">
-          <a class="effect-control" data-action="toggle" title="{{localize 'SMT_X.Effect.Toggle'}}">
-            <i class="fas {{#if effect.disabled}}fa-check{{else}}fa-times{{/if}}"></i>
-          </a>
-          <a class="effect-control" data-action="edit" title="{{localize 'DOCUMENT.Update' type="Effect"}}">
-            <i class="fas fa-edit"></i>
-          </a>
-          <a class="effect-control" data-action="delete" title="{{localize 'DOCUMENT.Delete' type="Effect"}}">
-            <i class="fas fa-trash"></i>
-          </a>
-        </div>
-      </li>
     {{/each}}
-    </ol>
+  </ol>
   {{/each}}
 </ol>


### PR DESCRIPTION
## v 0.890
- Preparser for Active Effects, now the value field can parse @key references to actor/item data
- Minor formatting changes
- Copied Kyane's quick-status-effect display icon row;
  - Left clicking an icon toggles it from Active/Inactive
  - Clicking on a bad status (Stone, panic) removes it instead
- Added an `@targets` keyword for COST fields only (for when a cost is paid per target, like "up to 2 bullets")
- Skills and Consumables can now affect HP, MP, or both.
- Added some new info to the heal/damage report messages that say how much MP was restored if any
- Consumable items now have a configuration sheet matching Features
- Minor bug fixes and code/data reorganization